### PR TITLE
Switch to pauseloop with no logs

### DIFF
--- a/cmd/wincat/Dockerfile
+++ b/cmd/wincat/Dockerfile
@@ -4,12 +4,17 @@ ARG nanoserverTag="mcr.microsoft.com/windows/nanoserver:1809-amd64"
 # Other common ones: 1803-amd64, 1903-amd64
 # full list: curl -L https://mcr.microsoft.com/v2/windows/nanoserver/tags/list
 ARG sigWindowsTag=master
+ARG windowsTestingTag=master
 
 FROM golang:${golangTag} as builder
-ENV srcdir="src\\github.com\\kubernetes-sigs\\sig-windows-tools"
-RUN mkdir $ENV:srcdir ; cd $ENV:srcdir ; git clone https://github.com/kubernetes-sigs/sig-windows-tools.git .
-RUN cd $ENV:srcdir ; cd cmd\wincat ; git fetch --all ; git checkout ${sigWindowsTag} ; git status ; go build -o wincat.exe .
+ENV pausesrcdir="src\\github.com\\kubernetes-sigs\\windows-testing"
+ENV wincatsrcdir="src\\github.com\\kubernetes-sigs\\sig-windows-tools"
+RUN mkdir $ENV:pausesrcdir ; cd $ENV:pausesrcdir ; git clone https://github.com/kubernetes-sigs/windows-testing.git .
+RUN mkdir $ENV:wincatsrcdir ; cd $ENV:wincatsrcdir ; git clone https://github.com/kubernetes-sigs/sig-windows-tools.git .
+RUN cd $ENV:pausesrcdir ; cd images\pause ; git fetch --all ; git checkout ${windowsTestingTag} ; git status ; go build -o pauseloop.exe .
+RUN cd $ENV:wincatsrcdir ; cd cmd\wincat ; git fetch --all ; git checkout ${sigWindowsTag} ; git status ; go build -o wincat.exe .
 
 FROM ${nanoserverTag}
 COPY --from=builder "c:\\gopath\\src\\github.com\\kubernetes-sigs\\sig-windows-tools\\cmd\\wincat\\wincat.exe" "c:\\windows\\system32\\wincat.exe"
-CMD cmd /c ping -t localhost
+COPY --from=builder "c:\\gopath\\src\\github.com\\kubernetes-sigs\\windows-testing\\images\\pause\\pauseloop.exe" "c:\\windows\\system32\\pauseloop.exe"
+CMD pauseloop.exe


### PR DESCRIPTION
Replaces #6, same code. I mistakenly made that PR in a branch here instead of in my fork. That prevented me from cleaning things up with a rebase.

Fixes kubernetes/kubernetes#81298

Later once we have a Windows build solution in place (proposed in https://github.com/kubernetes/kubernetes/pull/75618/files), we should move wincat and pause builds into the k/k repo.