### PR TITLE
Fixed issue related to multiple masters

### DIFF
--- a/kubeadm/v1.15.0/KubeClusterHelper.psm1
+++ b/kubeadm/v1.15.0/KubeClusterHelper.psm1
@@ -1195,7 +1195,7 @@ function GetKubeDnsServiceIp()
 
 function GetAPIServerEndpoint() {
     $endpoints = ConvertFrom-Json $(kubectl.exe get endpoints --all-namespaces -o json | Out-String)
-    $endpoints.Items | foreach { $i = $_; if ($i.Metadata.Name -eq "kubernetes") { return "$($i.subsets.addresses.ip):$($i.subsets.ports.port)" } }
+    $endpoints.Items | foreach { $i = $_; if ($i.Metadata.Name -eq "kubernetes") { return "$($i.subsets.addresses.ip[0]):$($i.subsets.ports.port)" } }
 }
 
 function GetKubeNodes()

--- a/kubeadm/v1.15.0/KubeClusterHelper.psm1
+++ b/kubeadm/v1.15.0/KubeClusterHelper.psm1
@@ -1195,7 +1195,7 @@ function GetKubeDnsServiceIp()
 
 function GetAPIServerEndpoint() {
     $endpoints = ConvertFrom-Json $(kubectl.exe get endpoints --all-namespaces -o json | Out-String)
-    $endpoints.Items | foreach { $i = $_; if ($i.Metadata.Name -eq "kubernetes") { return "$($i.subsets.addresses.ip[0]):$($i.subsets.ports.port)" } }
+    $endpoints.Items | foreach { $i = $_; if ($i.Metadata.Name -eq "kubernetes") { return "$($i.subsets.addresses.ip[0]):$($i.subsets.ports[0].port)" } }
 }
 
 function GetKubeNodes()


### PR DESCRIPTION
GetAPIServerEndpoint returns multiple master IP addresses when the cluster is set to allow redundant masters. The behavior was changed to select the zeroth master, which should propagate changes to other available masters in the cluster.