### PR TITLE
Wait for management IP interface before FlannelD service will start.

### DIFF
--- a/kubeadm/v1.15.0/KubeCluster.ps1
+++ b/kubeadm/v1.15.0/KubeCluster.ps1
@@ -267,7 +267,8 @@ if ($Join.IsPresent)
     if ($Global:Cni -eq "flannel")
     {
         CreateExternalNetwork -NetworkMode $Global:NetworkMode -InterfaceName $Global:InterfaceName
-        StartFlanneld 
+        WaitForNetworkInterface -IpAddress $Global:ManagementIp
+        StartFlanneld
         WaitForNetwork $Global:NetworkName
     }
 

--- a/kubeadm/v1.15.0/KubeClusterHelper.psm1
+++ b/kubeadm/v1.15.0/KubeClusterHelper.psm1
@@ -247,6 +247,27 @@ function WaitForNetwork($NetworkName, $waitTimeSeconds = 60)
     }
 }
 
+function WaitForNetworkInterface($IpAddress, $waitTimeSeconds = 60)
+{
+    $startTime = Get-Date
+
+    # Wait till the interface is available
+    while ($true)
+    {
+        $timeElapsed = $(Get-Date) - $startTime
+        if ($($timeElapsed).TotalSeconds -ge $waitTimeSeconds)
+        {
+            throw "Fail to create the interface [($IpAddress)] in $waitTimeSeconds seconds"
+        }
+        if (Get-NetIPAddress | ? IPAddress -EQ $IpAddress)
+        {
+            break;
+        }
+        Write-Host "Waiting for the interface ($IpAddress) to be available"
+        Start-Sleep 5
+    }
+}
+
 function IsNodeRegistered()
 {
     kubectl.exe get nodes/$($(hostname).ToLower())
@@ -1297,6 +1318,7 @@ Export-ModuleMember DownloadFile
 Export-ModuleMember CleanupOldNetwork
 Export-ModuleMember IsNodeRegistered
 Export-ModuleMember WaitForNetwork
+Export-ModuleMember WaitForNetworkInterface
 Export-ModuleMember GetSourceVip
 Export-ModuleMember Get-PodCIDR
 Export-ModuleMember Get-PodCIDRs


### PR DESCRIPTION
FlannelD attempts to start the service immediately after creating
an external network. It's so fast that the network interface
is not available on time.

FlannelD service start fails with the following output:
```
I(...)    6124 main.go:450] Searching for interface using <ManagementIP>
I(...)    6124 main.go:210] Could not find valid interface matching <ManagementIP>: error looking up interface <ManagementIP>: Interface not found: <ManagementIP>
E(...)    6124 main.go:234] Failed to find interface to use that matches the interfaces and/or regexes provided
```