### PR TITLE
Use tilde (~) to resolve the home directory (vagrant case)

### DIFF
--- a/kubeadm/v1.15.0/KubeCluster.ps1
+++ b/kubeadm/v1.15.0/KubeCluster.ps1
@@ -193,7 +193,7 @@ if ($install.IsPresent)
     InstallKubernetesBinaries -Destination  $Global:BaseDir -Source $Global:ClusterConfiguration.Kubernetes.Source
     DownloadCniBinaries -NetworkMode $Global:NetworkMode -CniPath $(GetCniPath)
 
-    if (!(Test-Path ~/.ssh/id_rsa.pub))
+    if (!(Test-Path "$(GetUserDir)/.ssh/id_rsa.pub"))
     {
         $res = Read-Host "Do you wish to generate a SSH Key & Add it to the Linux control-plane node [Y/n] - Default [Y]"
         if ($res -eq '' -or $res -eq 'Y'  -or $res -eq 'y')
@@ -202,7 +202,7 @@ if ($install.IsPresent)
         }
     }
 
-    $pubKey = Get-Content ~/.ssh/id_rsa.pub
+    $pubKey = Get-Content "$(GetUserDir)/.ssh/id_rsa.pub"
     Write-Host "Execute the below commands on the Linux control-plane node ($Global:MasterIp) to add this Windows node's public key to its authorized keys"
     
     Write-Host "touch ~/.ssh/authorized_keys"
@@ -309,6 +309,6 @@ elseif ($Reset.IsPresent)
     UninstallKubernetesBinaries -Destination  $Global:BaseDir
 
     Remove-Item $Global:BaseDir -ErrorAction SilentlyContinue
-    Remove-Item ~\.kube -ErrorAction SilentlyContinue
+    Remove-Item "$(GetUserDir)\.kube" -ErrorAction SilentlyContinue
     RemoveExternalNetwork
 }

--- a/kubeadm/v1.15.0/KubeCluster.ps1
+++ b/kubeadm/v1.15.0/KubeCluster.ps1
@@ -193,7 +193,7 @@ if ($install.IsPresent)
     InstallKubernetesBinaries -Destination  $Global:BaseDir -Source $Global:ClusterConfiguration.Kubernetes.Source
     DownloadCniBinaries -NetworkMode $Global:NetworkMode -CniPath $(GetCniPath)
 
-    if (!(Test-Path $env:HOMEDRIVE/$env:HOMEPATH/.ssh/id_rsa.pub))
+    if (!(Test-Path ~/.ssh/id_rsa.pub))
     {
         $res = Read-Host "Do you wish to generate a SSH Key & Add it to the Linux control-plane node [Y/n] - Default [Y]"
         if ($res -eq '' -or $res -eq 'Y'  -or $res -eq 'y')
@@ -202,7 +202,7 @@ if ($install.IsPresent)
         }
     }
 
-    $pubKey = Get-Content $env:HOMEDRIVE/$env:HOMEPATH/.ssh/id_rsa.pub
+    $pubKey = Get-Content ~/.ssh/id_rsa.pub
     Write-Host "Execute the below commands on the Linux control-plane node ($Global:MasterIp) to add this Windows node's public key to its authorized keys"
     
     Write-Host "touch ~/.ssh/authorized_keys"
@@ -309,6 +309,6 @@ elseif ($Reset.IsPresent)
     UninstallKubernetesBinaries -Destination  $Global:BaseDir
 
     Remove-Item $Global:BaseDir -ErrorAction SilentlyContinue
-    Remove-Item $env:HOMEDRIVE\$env:HOMEPATH\.kube -ErrorAction SilentlyContinue
+    Remove-Item ~\.kube -ErrorAction SilentlyContinue
     RemoveExternalNetwork
 }

--- a/kubeadm/v1.15.0/KubeClusterHelper.psm1
+++ b/kubeadm/v1.15.0/KubeClusterHelper.psm1
@@ -33,6 +33,18 @@ function GetLogDir()
     return [io.Path]::Combine($Global:BaseDir, "logs");
 }
 
+function GetUserDir()
+{
+    if ($env:HOMEDRIVE -and $env:HOMEPATH)
+    {
+        Join-Path $env:HOMEDRIVE $env:HOMEPATH
+    }
+    else
+    {
+        (Resolve-Path ~).Path
+    }
+}
+
 function GetCniPath()
 {
     return [io.Path]::Combine($Global:BaseDir, "cni");
@@ -1298,6 +1310,7 @@ Export-ModuleMember CleanupOldNetwork
 Export-ModuleMember IsNodeRegistered
 Export-ModuleMember WaitForNetwork
 Export-ModuleMember GetSourceVip
+Export-ModuleMember GetUserDir
 Export-ModuleMember Get-PodCIDR
 Export-ModuleMember Get-PodCIDRs
 Export-ModuleMember Get-PodEndpointGateway


### PR DESCRIPTION
The environment variables `$env:HOMEDRIVE` and `$env:HOMEPATH` are empty
when vagrant executes `KubeCluster.ps1 -install`.
It makes _SSH key_ is not found even when it is correctly provisioned.
Script asks to generate _SSH key_ but it shouldn't do it.