### PR TITLE
Add DNS capability to cni conf

### DIFF
--- a/kubeadm/v1.15.0/KubeClusterHelper.psm1
+++ b/kubeadm/v1.15.0/KubeClusterHelper.psm1
@@ -525,6 +525,9 @@ Update-CNIConfig
             "cniVersion": "0.2.0",
             "name": "<NetworkMode>",
             "type": "flannel",
+            "capabilities": {
+              "dns": true
+            },
             "delegate": {
                "type": "win-bridge",
                 "dns" : {
@@ -564,6 +567,9 @@ Update-CNIConfig
             "cniVersion": "0.2.0",
             "name": "<NetworkMode>",
             "type": "flannel",
+            "capabilities": {
+              "dns": true
+            },
             "delegate": {
                "type": "win-overlay",
                 "dns" : {


### PR DESCRIPTION
This tells Kubernetes to pass dynamic DNS configuration to the CNI plugins. Without this you end up having only `svc.cluster.local` in your search list.
@ksubrmnn @ddebroy

https://github.com/kubernetes/kubernetes/pull/67435
https://github.com/containernetworking/cni/pull/639