### PR TITLE
copy config after generating

### DIFF
--- a/kubeadm/v1.15.0/KubeClusterHelper.psm1
+++ b/kubeadm/v1.15.0/KubeClusterHelper.psm1
@@ -1286,6 +1286,8 @@ function InstallCNI($cni, $NetworkMode, $ManagementIp, $CniPath, $InterfaceName)
                 -ClusterCIDR (GetClusterCidr) `
                 -NetworkName $Global:NetworkName -NetworkMode $Global:NetworkMode
 
+            Copy-Item $(GetFlannelNetConf) $(GetKubeFlannelPath)
+
             break
         }
     } 


### PR DESCRIPTION
fixes #21 

This PR should fix this.
But as an alternative: maybe it's better to change the start-arguments of the flanneld-daemon to point to the config under c:\ProgramData\Kubernetes?

