### PR TITLE
Fixed hang/fail on FlannelD create of VXLAN

### DIFF
--- a/kubeadm/KubeClusterHelper.psm1
+++ b/kubeadm/KubeClusterHelper.psm1
@@ -261,7 +261,7 @@ function WaitForNetwork($NetworkName, $WaitTimeSeconds = 60, $DieOnFail = $true)
         }
         if ((Get-Service -Name FlannelD).Status -ne "Running")
         {
-            Write-Host "FlannelD service stopped unexpectecdly"
+            Write-Host "FlannelD service stopped unexpectedly"
             return $false
         }
         Write-Host "Waiting for the Network ($NetworkName) to be created by flanneld"


### PR DESCRIPTION
This change fixes an issue where 'FlannelD' service sometimes fails to create 'vxlan0' on first start. This change makes one attempt to turn it off and back on again before giving up and timing out.

This fixed the issue for me completely on Windows Server 1909 (SAC) with Kubernetes 1.16.3