### PR TITLE
Switch to a prerelease of flanneld

### DIFF
--- a/kubeadm/KubeClusterHelper.psm1
+++ b/kubeadm/KubeClusterHelper.psm1
@@ -301,12 +301,12 @@ function DownloadFlannelBinaries()
 {
     param(
         [Parameter(Mandatory = $false, Position = 0)]
-        [string] $Release = "0.11.0",
+        [string] $Release = "0.12.0-rc1",
         [string] $Destination = "c:\flannel"
     )
 
     Write-Host "Downloading Flannel binaries"
-    DownloadFile -Url  "https://github.com/coreos/flannel/releases/download/v${Release}/flanneld.exe" -Destination $Destination\flanneld.exe 
+    DownloadFile -Url  "https://github.com/benmoss/flannel/releases/download/v${Release}/flanneld.exe" -Destination $Destination\flanneld.exe
 }
 
 function GetKubeFlannelPath()


### PR DESCRIPTION
v0.11.0 (the latest release) is now quite old and doesn't create the HostRoute policy for vxlan networks

I built this flanneld.exe locally (using `make dist/flanneld.exe`) and uploaded it to my fork of flannel. Not ideal, but until they ship a new version it's better than having broken functionality.

https://github.com/kubernetes/kubernetes/issues/81938
https://github.com/coreos/flannel/issues/1208