### PR TITLE
add upgrade script for kubeadm

### DIFF
--- a/kubeadm/KubeClusterUpgrade.ps1
+++ b/kubeadm/KubeClusterUpgrade.ps1
@@ -1,0 +1,96 @@
+<#
+.SYNOPSIS
+Utility script to assist in upgrading of Kubernetes Windows worker Nodes
+
+.PARAMETER KubeVersion
+Kubernetes version to upgrade to. For example, 'v1.17.0'
+
+.EXAMPLE
+PS> .\KubeClusterUpgrade.ps1 -help
+Prints this help
+
+.EXAMPLE
+PS> .\KubeClusterUpgrade.ps1 -KubeVersion v1.17.0
+Upgrade this Windows worker Node to v1.17.0
+
+.LINK
+https://github.com/kubernetes-sigs/sig-windows-tools/tree/master/kubeadm
+#>
+
+Param(
+    [parameter(Mandatory = $false,HelpMessage="Print the help")]
+    [switch] $help,
+    [parameter(Mandatory = $false,HelpMessage="Kubernetes version to upgrade to. For example, 'v1.17.0'")]
+    $KubeVersion
+)
+
+function Usage()
+{
+    $bin = $PSCommandPath
+    Get-Help $bin -Detailed
+}
+
+# Handle --help
+if ($help.IsPresent)
+{
+    Usage
+    exit
+}
+
+
+$helperPath = "$PSScriptRoot\KubeClusterHelper.psm1"
+Import-Module $helperPath
+
+if (($KubeVersion -eq "") -or ($KubeVersion -eq $null))
+{
+    Write-Host "the parameter '-KubeVersion' is mandatory. See '-help'"
+    exit
+}
+
+function DownloadKubeBinary()
+{
+    param(
+    [parameter(Mandatory = $true)] $Name,
+    [parameter(Mandatory = $true)] $DestinationPath
+    )
+    Write-Host "# Downloading $Name binary..."
+    DownloadFile -Url https://dl.k8s.io/$KubeVersion/bin/windows/amd64/$Name.exe -Destination $DestinationPath/$Name.exe
+}
+
+function UpgradeKubeBinary()
+{
+    param(
+    [parameter(Mandatory = $true)] $Name,
+    [parameter(Mandatory = $true)] $SourcePath
+    )
+    $DestinationPath = (get-command "$Name.Exe" -ErrorAction Stop).Source
+    Write-Host "# Upgrading $Name binary..."
+    Move-Item -Path $SourcePath/$Name.exe -Destination $DestinationPath -Force
+}
+
+Write-Host "# Will now upgrade this Kubernetes Node to version '$KubeVersion'"
+
+$tmpPath = [System.IO.Path]::GetTempPath()
+
+# Upgrade kubeadm
+
+DownloadKubeBinary -Name "kubeadm" -DestinationPath $tmpPath
+UpgradeKubeBinary -Name "kubeadm" -SourcePath $tmpPath
+Write-Host "# Executing 'kubeadm upgrade node'"
+cmd /c kubeadm upgrade node
+
+# Upgrade kube-proxy
+
+DownloadKubeBinary -Name "kube-proxy" -DestinationPath $tmpPath
+Stop-Service kubeproxy
+UpgradeKubeBinary -Name "kube-proxy" -SourcePath $tmpPath
+Start-Service kubeproxy -ErrorAction Stop
+
+# Upgrade kubelet
+
+DownloadKubeBinary -Name "kubelet" -DestinationPath $tmpPath
+Stop-Service kubelet
+UpgradeKubeBinary -Name "kubelet" -SourcePath $tmpPath
+Start-Service kubelet -ErrorAction Stop
+
+Write-Host "Done!"


### PR DESCRIPTION
Add the script kubeadm/KubeClusterUpgrade.ps1 that handles
upgrades of Windows worker nodes created by kubeadm.

It does the following:
- Downloads new binaries.
- Calls "kubeadm upgrade node".
- Restarts kube-proxy and kubelet services.

Currently it does not:
- Update CNI as the version matrix there is unclear.
- Drain a worker as this is the responsibility of the cluster admin
(owner of admin.conf).

NOTE: i did not add this as part of KubeCluster.ps1 as the script is quite broken for me.
possibly my PowerShell version is too old or something.

xref
https://github.com/kubernetes-sigs/sig-windows-tools/issues/24
