### PR TITLE
Move from deprecated beta node labels

### DIFF
--- a/kubeadm/flannel/flannel-host-gw.yml
+++ b/kubeadm/flannel/flannel-host-gw.yml
@@ -96,11 +96,11 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                  - key: beta.kubernetes.io/os
+                  - key: kubernetes.io/os
                     operator: In
                     values:
                       - windows
-                  - key: beta.kubernetes.io/arch
+                  - key: kubernetes.io/arch
                     operator: In
                     values:
                       - amd64

--- a/kubeadm/flannel/flannel-overlay.yml
+++ b/kubeadm/flannel/flannel-overlay.yml
@@ -85,11 +85,11 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                  - key: beta.kubernetes.io/os
+                  - key: kubernetes.io/os
                     operator: In
                     values:
                       - windows
-                  - key: beta.kubernetes.io/arch
+                  - key: kubernetes.io/arch
                     operator: In
                     values:
                       - amd64

--- a/kubeadm/kube-proxy/kube-proxy.yml
+++ b/kubeadm/kube-proxy/kube-proxy.yml
@@ -70,7 +70,7 @@ spec:
         - mountPath: /var/lib/kube-proxy-windows
           name: kube-proxy-windows
       nodeSelector:
-        beta.kubernetes.io/os: windows
+        kubernetes.io/os: windows
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists


### PR DESCRIPTION
A tiny change I just noticed 😸 . The beta ones are deprecated and scheduled for removal in 1.18, according to [this comment](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/apis/well_known_labels.go#L30) anyway