### PR TITLE
kubeadm/hack: enable verbosity for CI

### DIFF
--- a/kubeadm/hack/ci-e2e.sh
+++ b/kubeadm/hack/ci-e2e.sh
@@ -21,6 +21,7 @@
 
 set -o nounset
 set -o pipefail
+set -o xtrace
 
 BOSKOS_HOST=${BOSKOS_HOST:-"boskos.test-pods.svc.cluster.local."}
 ARTIFACTS="${ARTIFACTS:-${PWD}/_artifacts}"
@@ -42,7 +43,7 @@ echo "using boskos host to checkout project: ${BOSKOS_HOST}"
 # Check out the account from Boskos and store the produced environment
 # variables in a temporary file.
 account_env_var_file="$(mktemp)"
-python hack/checkout_account.py 1>"${account_env_var_file}"
+python ./hack/checkout_account.py 1>"${account_env_var_file}"
 checkout_account_status="${?}"
 
 # If the checkout process was a success then load the account's
@@ -63,13 +64,13 @@ fi
 # using the checked out account periodically
 ARTIFACTS="${ARTIFACTS:-${PWD}/_artifacts}"
 mkdir -p "$ARTIFACTS/logs/"
-python -u hack/heartbeat_account.py >> "$ARTIFACTS/logs/boskos.log" 2>&1 &
+python -u ./hack/heartbeat_account.py >> "$ARTIFACTS/logs/boskos.log" 2>&1 &
 HEART_BEAT_PID=$(echo $!)
 
-hack/e2e-cluster-gcp.sh $*
+VERBOSE=1 ./hack/e2e-cluster-gcp.sh $*
 test_status="${?}"
 
 # If Boskos is being used then release the GCP project back to Boskos.
-[ -z "${BOSKOS_HOST:-}" ] || hack/checkin_account.py >> $ARTIFACTS/logs/boskos.log 2>&1
+[ -z "${BOSKOS_HOST:-}" ] || ./hack/checkin_account.py >> $ARTIFACTS/logs/boskos.log 2>&1
 
 exit "${test_status}"

--- a/kubeadm/hack/e2e-cluster-gcp.sh
+++ b/kubeadm/hack/e2e-cluster-gcp.sh
@@ -35,6 +35,10 @@ mkdir -p "${ARTIFACTS}/logs"
 # disable gcloud prompts
 export CLOUDSDK_CORE_DISABLE_PROMPTS=1
 
+# print the gcloud version
+echo "Using gcloud version:"
+gcloud -v
+
 cleanup() {
 	gcloud compute firewall-rules list --filter network="$CLUSTER_NAME" --format "value(selfLink.basename())" | \
 		xargs gcloud compute firewall-rules delete

--- a/kubeadm/hack/e2e-cluster-gcp.sh
+++ b/kubeadm/hack/e2e-cluster-gcp.sh
@@ -18,6 +18,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+if [[ -n "${VERBOSE}" ]]; then
+	set -o xtrace
+fi
+
 NODE_COUNT=${NODE_COUNT:-2}
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 CLUSTER_NAME=${CLUSTER_NAME:-"test-$(date +%s)"}


### PR DESCRIPTION
- enable xtrace for ci-e2e.sh and optional xtrace for e2e-cluster-gcp.sh
- use "./hack" instead of "hack/" when referenceing the hack path
- print the gcloud version

/assign @benmoss 
this will make it easier to surface issues in the e2e runtime when needed.
https://storage.googleapis.com/kubernetes-jenkins/logs/kubeadm-windows-gcp-k8s-stable/1237499840846368768/build-log.txt

