### PR TITLE
Prevent automatic reboots from Windows update on e2e nodes

### DIFF
--- a/kubeadm/hack/startup/windows.ps1
+++ b/kubeadm/hack/startup/windows.ps1
@@ -1,3 +1,7 @@
+# Windows updates cause the node to reboot at arbitrary times.
+& sc.exe config wuauserv start=disabled
+& sc.exe stop wuauserv
+
 curl.exe -sLO https://github.com/kubernetes-sigs/sig-windows-tools/releases/latest/download/PrepareNode.ps1
 .\PrepareNode.ps1 -KubernetesVersion VERSION
 


### PR DESCRIPTION
Borrowed from this [GCE Windows test code](https://github.com/kubernetes/kubernetes/blob/84dc7046797aad80f258b6740a98e79199c8bb4d/cluster/gce/windows/k8s-node-setup.psm1#L279)

@neolit123 