### PR TITLE
kubeadm/hack: run e2e tests in Serial, but skip Slow tests

### DIFF
--- a/kubeadm/hack/ci-e2e.sh
+++ b/kubeadm/hack/ci-e2e.sh
@@ -101,7 +101,7 @@ gcloud config set project "$GCP_PROJECT"
 gcloud config set compute/region "$GCP_REGION"
 gcloud config set compute/zone "$GCP_ZONE"
 
-VERBOSE=true PARALLEL=true ./hack/e2e-cluster-gcp.sh $*
+VERBOSE=true ./hack/e2e-cluster-gcp.sh $*
 test_status="${?}"
 
 # If Boskos is being used then release the GCP project back to Boskos.

--- a/kubeadm/hack/e2e-cluster-gcp.sh
+++ b/kubeadm/hack/e2e-cluster-gcp.sh
@@ -145,7 +145,7 @@ kubectl -n kube-system wait --for=condition=Ready pods --all --timeout=15m
 # setting this env prevents ginkgo e2e from trying to run provider setup
 export KUBERNETES_CONFORMANCE_TEST="y"
 
-SKIP="${SKIP:-\\[LinuxOnly\\]}"
+SKIP="${SKIP:-\\[LinuxOnly\\]|\\[Slow\\]}"
 FOCUS="${FOCUS:-"\\[Conformance\\]|\\[NodeConformance\\]|\\[sig-windows\\]"}"
 # if we set PARALLEL=true, skip serial tests set --ginkgo-parallel
 if [ "${PARALLEL:-false}" = "true" ]; then


### PR DESCRIPTION
we are seeing a lot of flakes when running the conformance suite in parallel.

/priority important-soon
/kind bug
/area test
/assign @benmoss 