### PR TITLE
Lower parallelism

### DIFF
--- a/kubeadm/hack/e2e-cluster-gcp.sh
+++ b/kubeadm/hack/e2e-cluster-gcp.sh
@@ -150,6 +150,7 @@ FOCUS="${FOCUS:-"\\[Conformance\\]|\\[NodeConformance\\]|\\[sig-windows\\]"}"
 # if we set PARALLEL=true, skip serial tests set --ginkgo-parallel
 if [ "${PARALLEL:-false}" = "true" ]; then
 	export GINKGO_PARALLEL=y
+	export GINKGO_PARALLEL_NODES=4
 	SKIP="\\[Serial\\]|${SKIP}"
 fi
 $(go env GOPATH)/src/sigs.k8s.io/windows-testing/gce/run-e2e.sh \


### PR DESCRIPTION
hack/ginkgo-e2e [defaults to 25](https://github.com/kubernetes/kubernetes/blob/84dc7046797aad80f258b6740a98e79199c8bb4d/hack/ginkgo-e2e.sh#L128-L132), which we speculate is causing test failures because it's overloading our nodes

/assign @neolit123 