### PR TITLE
hack/e2e: skip api-machinery Aggregator tests

### DIFF
--- a/kubeadm/hack/e2e-cluster-gcp.sh
+++ b/kubeadm/hack/e2e-cluster-gcp.sh
@@ -145,7 +145,9 @@ kubectl -n kube-system wait --for=condition=Ready pods --all --timeout=15m
 # setting this env prevents ginkgo e2e from trying to run provider setup
 export KUBERNETES_CONFORMANCE_TEST="y"
 
-SKIP="${SKIP:-\\[LinuxOnly\\]|\\[Slow\\]}"
+# TODO: investigate if the api-machinery "Aggregator" tests work once 1.18 is out
+# and potentially remove the skip for it here.
+SKIP="${SKIP:-\\[LinuxOnly\\]|\\[Slow\\]|Aggregator}"
 FOCUS="${FOCUS:-"\\[Conformance\\]|\\[NodeConformance\\]|\\[sig-windows\\]"}"
 # if we set PARALLEL=true, skip serial tests set --ginkgo-parallel
 if [ "${PARALLEL:-false}" = "true" ]; then


### PR DESCRIPTION
These tests are problematic for 1.17 as the have issues
around image pinning and HTTP status 200 with error bodies.

Some of these issues seem fixed in 1.18, but the test is still pinned
to k8s version / image.

https://github.com/kubernetes/kubernetes/pull/84735/files

Skip the test and add TODO note that this should be investigated in the future.

/kind bug
/assign @benmoss 
/priority important-soon
