### PR TITLE
Update flannel to release 0.12.0

### DIFF
--- a/kubeadm/flannel/Dockerfile
+++ b/kubeadm/flannel/Dockerfile
@@ -11,10 +11,9 @@ SHELL ["powershell", "-NoLogo", "-Command", "$ErrorActionPreference = 'Stop'; $P
 
 ARG cniVersion
 
-# Stuck on a prerelease flannel until https://github.com/coreos/flannel/issues/1231 is resolved
 RUN mkdir -force C:\k\flannel; \
   pushd C:\k\flannel; \
-  curl.exe -LO https://github.com/benmoss/flannel/releases/download/v0.12.0-rc1/flanneld.exe
+  curl.exe -LO https://github.com/coreos/flannel/releases/download/v0.12.0/flanneld.exe
 
 ADD hns.psm1 /k/flannel
 COPY --from=builder /gopath/build/setup.exe /k/flannel/setup.exe

--- a/kubeadm/flannel/flannel-host-gw.yml
+++ b/kubeadm/flannel/flannel-host-gw.yml
@@ -113,7 +113,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: kube-flannel
-        image: sigwindowstools/flannel:0.12.0-rc2
+        image: sigwindowstools/flannel:0.12.0
         command:
         - powershell
         args:

--- a/kubeadm/flannel/flannel-overlay.yml
+++ b/kubeadm/flannel/flannel-overlay.yml
@@ -102,7 +102,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: kube-flannel
-        image: sigwindowstools/flannel:0.12.0-rc2
+        image: sigwindowstools/flannel:0.12.0
         command:
         - powershell
         args:


### PR DESCRIPTION
/assign @neolit123 

https://github.com/coreos/flannel/releases/tag/v0.12.0 came out recently so we can finally move off of my release binary. I already pushed the image to the Docker Hub account under a new tag, so I'll make a new release of sig-windows-tools after this is merged.