### PR TITLE
Create docker host nat network on demand

### DIFF
--- a/kubeadm/scripts/PrepareNode.ps1
+++ b/kubeadm/scripts/PrepareNode.ps1
@@ -67,6 +67,12 @@ New-Item -path C:\var\lib\kubelet\etc\kubernetes\pki -type SymbolicLink -value C
 $StartKubeletFileContent = '$FileContent = Get-Content -Path "/var/lib/kubelet/kubeadm-flags.env"
 $global:KubeletArgs = $FileContent.Trim("KUBELET_KUBEADM_ARGS=`"")
 
+$netId = docker network ls -f name=host --format "{{ .ID }}"
+
+if ($netId.Length -lt 1) {
+    docker network create -d nat host
+}
+
 $cmd = "C:\k\kubelet.exe $global:KubeletArgs --cert-dir=$env:SYSTEMDRIVE\var\lib\kubelet\pki --config=/var/lib/kubelet/config.yaml --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf --hostname-override=$(hostname) --pod-infra-container-image=`"mcr.microsoft.com/k8s/core/pause:1.2.0`" --enable-debugging-handlers --cgroups-per-qos=false --enforce-node-allocatable=`"`" --network-plugin=cni --resolv-conf=`"`" --log-dir=/var/log/kubelet --logtostderr=false --image-pull-progress-deadline=20m"
 
 Invoke-Expression $cmd'


### PR DESCRIPTION
Workaround, fixes #52 

Not really beautiful doing that inside the kubelet start script but it's the easiest solution. 

Another alternative would be to create another external script file and somehow set up something like the Windows task scheduler to run it on startup. But then we would also need to make sure that this script waits for startup of the docker service which adds additional complexity.