### PR TITLE
Add back --ip-masq cmdline argument to flanneld.

### DIFF
--- a/kubeadm/flannel/flannel-host-gw.yml
+++ b/kubeadm/flannel/flannel-host-gw.yml
@@ -34,7 +34,7 @@ data:
     cp -force /var/run/secrets/kubernetes.io/serviceaccount/* /host/k/flannel/var/run/secrets/kubernetes.io/serviceaccount/
     wins cli process run --path /k/flannel/setup.exe --args "--mode=l2bridge --interface=Ethernet"
     wins cli route add --addresses 169.254.169.254
-    wins cli process run --path /k/flannel/flanneld.exe --args "--kube-subnet-mgr --kubeconfig-file /k/flannel/kubeconfig.yml" --envs "POD_NAME=$env:POD_NAME POD_NAMESPACE=$env:POD_NAMESPACE"
+    wins cli process run --path /k/flannel/flanneld.exe --args "--ip-masq --kube-subnet-mgr --kubeconfig-file /k/flannel/kubeconfig.yml" --envs "POD_NAME=$env:POD_NAME POD_NAMESPACE=$env:POD_NAMESPACE"
   cni-conf.json: |
     {
       "name": "cbr0",

--- a/kubeadm/flannel/flannel-overlay.yml
+++ b/kubeadm/flannel/flannel-overlay.yml
@@ -33,7 +33,7 @@ data:
     cp -force /var/run/secrets/kubernetes.io/serviceaccount/* /host/k/flannel/var/run/secrets/kubernetes.io/serviceaccount/
     wins cli process run --path /k/flannel/setup.exe --args "--mode=overlay --interface=Ethernet"
     wins cli route add --addresses 169.254.169.254
-    wins cli process run --path /k/flannel/flanneld.exe --args "--kube-subnet-mgr --kubeconfig-file /k/flannel/kubeconfig.yml" --envs "POD_NAME=$env:POD_NAME POD_NAMESPACE=$env:POD_NAMESPACE"
+    wins cli process run --path /k/flannel/flanneld.exe --args "--ip-masq --kube-subnet-mgr --kubeconfig-file /k/flannel/kubeconfig.yml" --envs "POD_NAME=$env:POD_NAME POD_NAMESPACE=$env:POD_NAMESPACE"
   cni-conf.json: |
     {
       "name": "flannel.4096",


### PR DESCRIPTION
From flannel docs:

  --ip-masq=false: setup IP masquerade for traffic destined for outside the flannel network.

Fixes https://github.com/kubernetes-sigs/sig-windows-tools/issues/77
