### PR TITLE
Remove the hardcoded --interface argument that gets fed into New-HnsNetwork

### DIFF
--- a/kubeadm/flannel/flannel-host-gw.yml
+++ b/kubeadm/flannel/flannel-host-gw.yml
@@ -32,7 +32,7 @@ data:
     cp -force /k/flannel/* /host/k/flannel/
     cp -force /kube-proxy/kubeconfig.conf /host/k/flannel/kubeconfig.yml
     cp -force /var/run/secrets/kubernetes.io/serviceaccount/* /host/k/flannel/var/run/secrets/kubernetes.io/serviceaccount/
-    wins cli process run --path /k/flannel/setup.exe --args "--mode=l2bridge --interface=Ethernet"
+    wins cli process run --path /k/flannel/setup.exe --args "--mode=l2bridge"
     wins cli route add --addresses 169.254.169.254
     wins cli process run --path /k/flannel/flanneld.exe --args "--kube-subnet-mgr --kubeconfig-file /k/flannel/kubeconfig.yml" --envs "POD_NAME=$env:POD_NAME POD_NAMESPACE=$env:POD_NAMESPACE"
   cni-conf.json: |

--- a/kubeadm/flannel/flannel-overlay.yml
+++ b/kubeadm/flannel/flannel-overlay.yml
@@ -31,7 +31,7 @@ data:
     cp -force /k/flannel/* /host/k/flannel/
     cp -force /kube-proxy/kubeconfig.conf /host/k/flannel/kubeconfig.yml
     cp -force /var/run/secrets/kubernetes.io/serviceaccount/* /host/k/flannel/var/run/secrets/kubernetes.io/serviceaccount/
-    wins cli process run --path /k/flannel/setup.exe --args "--mode=overlay --interface=Ethernet"
+    wins cli process run --path /k/flannel/setup.exe --args "--mode=overlay"
     wins cli route add --addresses 169.254.169.254
     wins cli process run --path /k/flannel/flanneld.exe --args "--kube-subnet-mgr --kubeconfig-file /k/flannel/kubeconfig.yml" --envs "POD_NAME=$env:POD_NAME POD_NAMESPACE=$env:POD_NAMESPACE"
   cni-conf.json: |


### PR DESCRIPTION
This argument seems to not be necessary, and creates difficulty in  environments where  you don't have a consistent device name for the default NIC across all your nodes.

Fixes: https://github.com/kubernetes-sigs/sig-windows-tools/issues/81