### PR TITLE
Fix DSR enablement for l2bridge clusters

### DIFF
--- a/kubeadm/KubeCluster.ps1
+++ b/kubeadm/KubeCluster.ps1
@@ -361,7 +361,8 @@ if ($Join.IsPresent)
         $env:KUBE_NETWORK=$Global:NetworkName
         InstallKubeProxy -KubeConfig $(GetKubeConfig) `
             -IsDsr:$Global:DsrEnabled `
-            -NetworkName $Global:NetworkName -ClusterCIDR  $ClusterCIDR
+            -NetworkName $Global:NetworkName -ClusterCIDR  $ClusterCIDR `
+            -ProxyFeatureGates $Global:KubeproxyGates
     }
     
     StartKubeproxy


### PR DESCRIPTION
When the network type is l2bridge, we must still pass `-ProxyFeatureGates $Global:KubeproxyGates` to `InstallKubeProxy` in order to successfully enable DSR. 

The function `GetProxyArguments` in `KubeClusterHelper.psm1` ultimately relies on `$ProxyFeatureGates` to pass the `--enable-dsr=true` flag on to kubeproxy. 