### PR TITLE
Check that HNS network doesn't exist before creating new one

### DIFF
--- a/kubeadm/flannel/setup.go
+++ b/kubeadm/flannel/setup.go
@@ -10,7 +10,7 @@ import (
 
 func setupOverlay(interfaceName string) {
 	run(fmt.Sprintf(`ipmo C:\k\flannel\hns.psm1; `+
-                `$network = Get-HNSNetwork | ? Name -eq "External" `+
+                `$network = Get-HNSNetwork | ? Name -eq "External"; `+
                 `if ($network -eq $null) { `+
                 `New-HNSNetwork -Type Overlay -AddressPrefix "192.168.255.0/30" -Gateway "192.168.255.1" -Name "External" -AdapterName "%s" -SubnetPolicies @(@{Type = "VSID"; VSID = 9999; }); `+
                 `} elseif ($network.Type -ne "Overlay") { `+

--- a/kubeadm/flannel/setup.go
+++ b/kubeadm/flannel/setup.go
@@ -10,18 +10,24 @@ import (
 
 func setupOverlay(interfaceName string) {
 	run(fmt.Sprintf(`ipmo C:\k\flannel\hns.psm1; `+
-                `if ((Get-HNSNetwork | ?{ ($_.Type -eq "Overlay") -and ($_.Name -eq "External") }) -eq $null) { `+
-                `New-HNSNetwork -Type Overlay -AddressPrefix "192.168.255.0/30" `+
-		`-Gateway "192.168.255.1" -Name "External" -AdapterName "%s" -SubnetPolicies @(@{Type = "VSID"; VSID = 9999; }); }`,
+                `$network = Get-HNSNetwork | ? Name -eq "External" `+
+                `if ($network -eq $null) { `+
+                `New-HNSNetwork -Type Overlay -AddressPrefix "192.168.255.0/30" -Gateway "192.168.255.1" -Name "External" -AdapterName "%s" -SubnetPolicies @(@{Type = "VSID"; VSID = 9999; }); `+
+                `} elseif ($network.Type -ne "Overlay") { `+
+                `Write-Warning "'External' network already exists but has wrong type: $($network.Type)." `+
+                `}`,
 		interfaceName),
 	)
 }
 
 func setupL2bridge(interfaceName string) {
 	run(fmt.Sprintf(`ipmo C:\k\flannel\hns.psm1; `+
-                `if ((Get-HNSNetwork | ?{ ($_.Type -eq "Overlay") -and ($_.Name -eq "External") }) -eq $null) { `+
-                `New-HNSNetwork -Type Overlay -AddressPrefix "192.168.255.0/30" `+
-		`-Gateway "192.168.255.1" -Name "External" -AdapterName "%s"; }`,
+                `$network = Get-HNSNetwork | ? Name -eq "External" `+
+                `if ($network -eq $null) { `+
+                `New-HNSNetwork -Type Overlay -AddressPrefix "192.168.255.0/30" -Gateway "192.168.255.1" -Name "External" -AdapterName "%s"; `+
+                `} elseif ($network.Type -ne "Overlay") { `+
+                `Write-Warning "'External' network already exists but has wrong type: $($network.Type)." `+
+                `}`,
 		interfaceName),
 	)
 }

--- a/kubeadm/flannel/setup.go
+++ b/kubeadm/flannel/setup.go
@@ -22,7 +22,7 @@ func setupOverlay(interfaceName string) {
 
 func setupL2bridge(interfaceName string) {
 	run(fmt.Sprintf(`ipmo C:\k\flannel\hns.psm1; `+
-                `$network = Get-HNSNetwork | ? Name -eq "External" `+
+                `$network = Get-HNSNetwork | ? Name -eq "External"; `+
                 `if ($network -eq $null) { `+
                 `New-HNSNetwork -Type Overlay -AddressPrefix "192.168.255.0/30" -Gateway "192.168.255.1" -Name "External" -AdapterName "%s"; `+
                 `} elseif ($network.Type -ne "Overlay") { `+

--- a/kubeadm/flannel/setup.go
+++ b/kubeadm/flannel/setup.go
@@ -9,15 +9,19 @@ import (
 )
 
 func setupOverlay(interfaceName string) {
-	run(fmt.Sprintf(`ipmo C:\k\flannel\hns.psm1; New-HNSNetwork -Type Overlay -AddressPrefix "192.168.255.0/30"`+
-		`-Gateway "192.168.255.1" -Name "External" -AdapterName "%s" -SubnetPolicies @(@{Type = "VSID"; VSID = 9999; })`,
+	run(fmt.Sprintf(`ipmo C:\k\flannel\hns.psm1; `+
+                `if ((Get-HNSNetwork | ?{ ($_.Type -eq "Overlay") -and ($_.Name -eq "External") }) -eq $null) { `+
+                `New-HNSNetwork -Type Overlay -AddressPrefix "192.168.255.0/30" `+
+		`-Gateway "192.168.255.1" -Name "External" -AdapterName "%s" -SubnetPolicies @(@{Type = "VSID"; VSID = 9999; }); }`,
 		interfaceName),
 	)
 }
 
 func setupL2bridge(interfaceName string) {
-	run(fmt.Sprintf(`ipmo C:\k\flannel\hns.psm1; New-HNSNetwork -Type Overlay -AddressPrefix "192.168.255.0/30"`+
-		`-Gateway "192.168.255.1" -Name "External" -AdapterName "%s"`,
+	run(fmt.Sprintf(`ipmo C:\k\flannel\hns.psm1; `+
+                `if ((Get-HNSNetwork | ?{ ($_.Type -eq "Overlay") -and ($_.Name -eq "External") }) -eq $null) { `+
+                `New-HNSNetwork -Type Overlay -AddressPrefix "192.168.255.0/30" `+
+		`-Gateway "192.168.255.1" -Name "External" -AdapterName "%s"; }`,
 		interfaceName),
 	)
 }


### PR DESCRIPTION
When we restart flannel pod we can see error message like this:
```
Invoke-HnsRequest : @{Error=A network with this name already exists. ; ErrorCode=2151350288; Success=False}
At C:\k\flannel\hns.psm1:233 char:16
+ ...      return Invoke-HnsRequest -Method POST -Type networks -Data $Json ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Write-Error], WriteErrorException
    + FullyQualifiedErrorId : Microsoft.PowerShell.Commands.WriteErrorException,Invoke-HNSRequest
```
because HNS network 'External' already exists.