### PR TITLE
Update flannel docker image to 0.13.0

### DIFF
--- a/kubeadm/flannel/Dockerfile
+++ b/kubeadm/flannel/Dockerfile
@@ -13,7 +13,7 @@ ARG cniVersion
 
 RUN mkdir -force C:\k\flannel; \
   pushd C:\k\flannel; \
-  curl.exe -LO https://github.com/coreos/flannel/releases/download/v0.12.0/flanneld.exe
+  curl.exe -LO https://github.com/coreos/flannel/releases/download/v0.13.0/flanneld.exe
 
 ADD hns.psm1 /k/flannel
 COPY --from=builder /gopath/build/setup.exe /k/flannel/setup.exe


### PR DESCRIPTION
Flannel 0.13.0 has been released. Maybe make sense build new image `sigwindowstools/flannel:0.13.0` to be consistent with it.

When new version of docker image ready we need to update yaml files:
- flannel-host-gw.yml
- flannel-overlay.yml