### PR TITLE
Ensures wrapping quotes removed from kubelet args

### DIFF
--- a/kubeadm/scripts/PrepareNode.ps1
+++ b/kubeadm/scripts/PrepareNode.ps1
@@ -65,7 +65,7 @@ mkdir -force C:\etc\kubernetes\pki
 New-Item -path C:\var\lib\kubelet\etc\kubernetes\pki -type SymbolicLink -value C:\etc\kubernetes\pki\
 
 $StartKubeletFileContent = '$FileContent = Get-Content -Path "/var/lib/kubelet/kubeadm-flags.env"
-$global:KubeletArgs = $FileContent.Trim("KUBELET_KUBEADM_ARGS=`"")
+$global:KubeletArgs = $FileContent.TrimStart('KUBELET_KUBEADM_ARGS=').Trim('"')
 
 $netId = docker network ls -f name=host --format "{{ .ID }}"
 


### PR DESCRIPTION
The existing code removed the environment variable name `KUBELET_KUBEADMARGS=` and the starting `"`, but did not move the ending `"`. Subsequently, when constructing the final list of arguments to pass to Kubelet, the trailing quote which was left behind would cause a string to be opened, and in some cases never closed, or in other cases, closing on something like `" --cert-dir="`, which results in an invalid command line. In either case, it can cause the Kubelet service to fail to start.

This commit resolves that issue by ensuring that wrapping quotes are trimmed from the string.