### PR TITLE
Add note about tricky rancher file rename for kube-proxy.exe

### DIFF
--- a/kubeadm/kube-proxy/kube-proxy.yml
+++ b/kubeadm/kube-proxy/kube-proxy.yml
@@ -39,6 +39,9 @@ data:
     yq w -i /host/var/lib/kube-proxy/config.conf winkernel.networkName $networkName
     yq w -i /host/var/lib/kube-proxy/config.conf featureGates.WinOverlay true
     yq w -i /host/var/lib/kube-proxy/config.conf mode "kernelspace"
+    
+    # Start the kube-proxy as a wins process on the host.
+    # Note that this will rename kube-proxy.exe to rancher-wins-kube-proxy.exe on the host!
     wins cli process run --path /k/kube-proxy/kube-proxy.exe --args "--v=6 --config=/var/lib/kube-proxy/config.conf --hostname-override=$env:NODE_NAME --feature-gates=WinOverlay=true"
 
 kind: ConfigMap

--- a/kubeadm/kube-proxy/kube-proxy.yml
+++ b/kubeadm/kube-proxy/kube-proxy.yml
@@ -32,6 +32,11 @@ data:
     cp -force /var/lib/kube-proxy/* /host/var/lib/kube-proxy
     cp -force /var/run/secrets/kubernetes.io/serviceaccount/* /host/var/lib/kube-proxy/var/run/secrets/kubernetes.io/serviceaccount #FIXME?
 
+    # If live patching kube-proxy, make sure and patch it inside this container, so that the SHA
+    # matches that of what is on the host. i.e. uncomment the below line...
+    # wget <download-path-to-kube-proxy.exe> -outfile k/kube-proxy/kube-proxy.exe
+    cp -force /k/kube-proxy/* /host/k/kube-proxy
+
     $cniConfFile = Get-NetConfFile
     $networkName = (Get-Content "/host/etc/cni/net.d/$cniConfFile" | ConvertFrom-Json).name
     $sourceVip = ($env:POD_IP -split "\.")[0..2] + 0 -join "."


### PR DESCRIPTION
just a quick note for this kube-proxy rename thats been puzzling me for an hour or so :).  
Seems like processes are renamed on the host to `rancher-wins-*`.  
It seems like we may want to plumb this in as a variable to rancher-wins someday.  

Created https://github.com/rancher/wins/issues/11 , in case theres any value in **not** renaming the file on startup.