### PR TITLE
Adding a github action to add tide/merge-method-squash to all PRs by default

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,3 @@
+# Add 'tide/merge-method-squash' to ALL pull requestsL
+tide/merge-method-squash:
+  - *

--- a/.github/workflows/labler.yml
+++ b/.github/workflows/labler.yml
@@ -1,0 +1,11 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@main
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION

**Reason for PR**:
<!-- What does this PR improve or fix? -->
Making the squash merges the default for this repo to help keep git history cleaner.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Issue #

**Requirements**

- [ ] Sqaush commits 
- [ ] Documentation
- [ ] Tests

**Notes**:


