### PR TITLE
Allow to password contains special symbols

### DIFF
--- a/.github/workflows/flannel.yml
+++ b/.github/workflows/flannel.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Build and push images
       if: ${{ github.event_name == 'push' }}
       run: |
-        echo ${{ secrets.DOCKER_SECRET }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+        echo "${{ secrets.DOCKER_SECRET }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
         $gittag = '-'+(($env:GITHUB_REF -split '/' | select-object -skip 2) -join '-')
         ./build.ps1 -push -tagSuffix $gittag
     - name: Build images (without push)

--- a/.github/workflows/kube-proxy.yml
+++ b/.github/workflows/kube-proxy.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Build and push images
       if: ${{ github.event_name == 'schedule' }}
       run: |
-        echo ${{ secrets.DOCKER_SECRET }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+        echo "${{ secrets.DOCKER_SECRET }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
         ./build.ps1 -push
     - name: Build images (without push)
       if: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
**Issue Fixed**:
Currently we have a problem with actions that failed because docker-hub password contains special symbols.
This is fix for it.