### PR TITLE
Explicity disable dualstack for win overlay

### DIFF
--- a/kubeadm/kube-proxy/kube-proxy.yml
+++ b/kubeadm/kube-proxy/kube-proxy.yml
@@ -43,6 +43,7 @@ data:
     yq w -i /host/var/lib/kube-proxy/config.conf winkernel.sourceVip $sourceVip
     yq w -i /host/var/lib/kube-proxy/config.conf winkernel.networkName $networkName
     yq w -i /host/var/lib/kube-proxy/config.conf featureGates.WinOverlay true
+    yq w -i /host/var/lib/kube-proxy/config.conf featureGates.IPv6DualStack false
     yq w -i /host/var/lib/kube-proxy/config.conf mode "kernelspace"
     
     # Start the kube-proxy as a wins process on the host.


### PR DESCRIPTION
**Reason for PR**:
<!-- What does this PR improve or fix? -->
1.21 broke win overlay with dualstack: https://github.com/kubernetes/kubernetes/issues/100966

The kubeadm tests are broken becuase of this:
https://testgrid.k8s.io/sig-windows-master-release#kubeadm-windows-gcp-k8s-stable

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Issue #

**Requirements**

- [ ] Sqaush commits 
- [ ] Documentation
- [ ] Tests

**Notes**:


/assign @marosset @neolit123 