### PR TITLE
A more precise filter to identify DNS service

### DIFF
--- a/kubeadm/KubeClusterHelper.psm1
+++ b/kubeadm/KubeClusterHelper.psm1
@@ -1211,7 +1211,7 @@ function ReadKubeClusterInfo()
 function GetKubeDnsServiceIp()
 {
     $svc = ConvertFrom-Json $(kubectl.exe get services -n kube-system -o json | Out-String)
-    $svc.Items | foreach { $i = $_; if ($i.Metadata.Name -match "dns") { return $i.spec.ClusterIP } }
+    $svc.Items | foreach { $i = $_; if ($i.Metadata.Name -match "kube-dns") { return $i.spec.ClusterIP } }
 }
 
 function GetAPIServerEndpoint() {


### PR DESCRIPTION
**Reason for PR**:
In my case, I have prometheus stack deployed in the kube-system namespace.
It may bring a problem when the script is looking for a DNS service.
Current code behaviors are as follows:

```
(kubectl.exe get services -n kube-system -o json | ConvertFrom-Json).items | ? { $_.Metadata.Name -match 'dns' } | % { @{ $_.metadata.Name = $_.spec.ClusterIP  } } | ft -AutoSize

Name                               Value
----                               -----
kube-dns                           10.96.0.10
my-prometheus-stack-kube-p-coredns None
```

This commit makes the algorithm a little bit more precise.

**Requirements**

- [v] Squash commits 
