### PR TITLE
Make base image configurable

### DIFF
--- a/burrito/Dockerfile
+++ b/burrito/Dockerfile
@@ -1,10 +1,13 @@
-FROM golang:1.16-alpine as builder
+ARG BUILDER_IMAGE=golang:1.16-alpine
+ARG RUN_IMAGE=alpine:latest
+
+FROM ${BUILDER_IMAGE} as builder
 
 COPY . /burrito
 WORKDIR /burrito
 RUN go build
 
-FROM alpine:latest as run
+FROM ${RUN_IMAGE} as run
 WORKDIR /root/
 COPY --from=builder /burrito/burrito burrito
 RUN chmod +x burrito


### PR DESCRIPTION
Add 2 ARGS to make builder image and run iamge configurable, you may
pass build args through --build-arg:
    docker build -t <image:tag> \
        --build-arg BUILDER_IMAGE=<builder-image-path> \
        --build-arg RUN_IMAGE=<run-image-path>

**Reason for PR**:
Now the base builder image and run image are hardcode, this change is to make it configurable.


**Issue Fixed**:
https://github.com/kubernetes-sigs/sig-windows-tools/issues/165

**Requirements**

- [ ] Sqaush commits 
- [ ] Documentation
- [ ] Tests

**Notes**:

docker build --rm -t ccc:eee --build-arg BUILDER_IMAGE=harbor-repo.vmware.com/dockerhub-proxy-cache/library/golang:1.16-alpine --build-arg RUN_IMAGE=harbor-repo.vmware.com/dockerhub-proxy-cache/library/alpine:latest .

