### PR TITLE
Fetching files in the build phase

### DIFF
--- a/burrito/Dockerfile
+++ b/burrito/Dockerfile
@@ -12,4 +12,10 @@ WORKDIR /root/
 COPY --from=builder /burrito/burrito burrito
 RUN chmod +x burrito
 
-CMD ["./burrito", "serve", "-b"]
+ARG CONFIG_FILE=examples/burrito.yaml
+COPY --from=builder /burrito/${CONFIG_FILE} .
+RUN mv $(basename "${CONFIG_FILE}") .burrito.${CONFIG_FILE##*.} \
+  && ls -la \
+  && ./burrito build
+
+CMD ["./burrito", "serve"]

--- a/burrito/docker-compose.yml
+++ b/burrito/docker-compose.yml
@@ -2,9 +2,9 @@ version: '3.9'
 
 services:
   burrito:
-    build: .
-    volumes:
-    - ./examples/burrito.yaml:/root/.burrito.yaml
-    - ./files:/root/files
+    build:
+      context: .
+      args:
+        CONFIG_FILE: ./examples/burrito.yaml
     ports:
       - "3000:3000"

--- a/burrito/examples/burrito.yaml
+++ b/burrito/examples/burrito.yaml
@@ -1,4 +1,4 @@
-httpRoot: localhost
+httpRoot: 0.0.0.0
 port: 3000
 fsDir: files
 components:


### PR DESCRIPTION
**Reason for PR**:
Current burrito is an empty burrito image, it downloads file in the run phase only, we need a burrito image with files already pulled. In this change a new ARG 'CONFIG_FILE' is added, which indicates the file list to be downloaded, we may pass an ARG to 'docker build':
         docker build --build-arg CONFIG_FILE=<path-to-config-file> ......


**Issue Fixed**:
N/A

**Requirements**

- [ ] Sqaush commits 
- [ ] Documentation
- [ ] Tests

**Notes**:


