### PR TITLE
Remove doubled apiVersion in kube-proxy.yml

### DIFF
--- a/kubeadm/kube-proxy/kube-proxy.yml
+++ b/kubeadm/kube-proxy/kube-proxy.yml
@@ -1,4 +1,3 @@
-apiVersion: v1
 data:
   run-script.ps1: |-
     $ErrorActionPreference = "Stop";


### PR DESCRIPTION
**Reason for PR**:
Removes the doubled `apiVersion` key from `kube-proxy.yml` as kustomize bails out with:
```
Error: map[string]interface {}(nil): yaml: unmarshal errors:
line 52: mapping key "apiVersion" already defined at line 1
```

**Issue Fixed**:
No issue created

**Requirements**

- [ ] Sqaush commits 
- [ ] Documentation
- [ ] Tests

**Notes**:


