### PR TITLE
Flannel host-gw: allow communication within the same subnet

### DIFF
--- a/kubeadm/flannel/flannel-host-gw.yml
+++ b/kubeadm/flannel/flannel-host-gw.yml
@@ -31,7 +31,7 @@ data:
     if ($containerRuntime -eq "docker") {
       $cniJson = get-content /etc/kube-flannel-windows/cni-conf.json | ConvertFrom-Json
 
-      $cniJson.delegate.policies[0].Value.ExceptionList = $serviceSubnet, $podSubnet, $networkJson.SubnetCIDR
+      $cniJson.delegate.policies[0].Value.ExceptionList = $serviceSubnet, $podSubnet, $networkJson.AddressCIDR
       $cniJson.delegate.policies[1].Value.DestinationPrefix = $serviceSubnet
       $cniJson.delegate.policies[2].Value.DestinationPrefix = $networkJson.AddressCIDR
 
@@ -39,7 +39,7 @@ data:
     } elseif ($containerRuntime -eq "containerd") {
       $cniJson = get-content /etc/kube-flannel-windows/cni-conf-containerd.json | ConvertFrom-Json
 
-      $cniJson.delegate.AdditionalArgs[0].Value.Settings.Exceptions = $serviceSubnet, $podSubnet, $networkJson.SubnetCIDR
+      $cniJson.delegate.AdditionalArgs[0].Value.Settings.Exceptions = $serviceSubnet, $podSubnet, $networkJson.AddressCIDR
       $cniJson.delegate.AdditionalArgs[1].Value.Settings.DestinationPrefix = $serviceSubnet
       $cniJson.delegate.AdditionalArgs[2].Value.Settings.DestinationPrefix = $networkJson.AddressCIDR
 


### PR DESCRIPTION
**Reason for PR**:
On our setup, pods need to contact services that live outside the cluster but inside the same (physical) subnet.

With the current flannel host-gw exception list that was not possible. This PR fixes it by removing the subnet from flannel exception list and adding the host IP address instead.

Please give feedback.
Thanks!

**Issue Fixed**:
"Flannel Host-GW: Cannot contact hosts within the same subnet" (Don't have an issue number)

**Requirements**

- [ ] Sqaush commits 
- [ ] Documentation
- [ ] Tests

**Notes**:


