### PR TITLE
Add a versions file

### DIFF
--- a/burrito/Dockerfile
+++ b/burrito/Dockerfile
@@ -7,15 +7,25 @@ COPY . /burrito
 WORKDIR /burrito
 RUN go build
 
+# Just create an empty one if it is not specified
+RUN touch .versions
+
 FROM ${RUN_IMAGE} as run
+
 WORKDIR /root/
 COPY --from=builder /burrito/burrito burrito
 RUN chmod +x burrito
 
+# Relative path in /burrito
 ARG CONFIG_FILE=examples/burrito.yaml
 COPY --from=builder /burrito/${CONFIG_FILE} .
 RUN mv $(basename "${CONFIG_FILE}") .burrito.${CONFIG_FILE##*.} \
   && ls -la \
   && ./burrito build
+
+# Relative path in /burrito
+ARG VERSIONS_FILE=.versions
+COPY --from=builder /burrito/${VERSIONS_FILE} .
+RUN mv $(basename "${VERSIONS_FILE}") .versions
 
 CMD ["./burrito", "serve"]

--- a/burrito/cmd/root.go
+++ b/burrito/cmd/root.go
@@ -27,6 +27,7 @@ import (
 
 var (
 	cfgFile string
+	verFile string
 	mc      utils.BurritoConfig
 )
 
@@ -48,6 +49,7 @@ func Execute() {
 func init() {
 	cobra.OnInitialize(initConfig)
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.burrito.yaml)")
+	rootCmd.PersistentFlags().StringVar(&verFile, "versions", "", "versions file (default is $HOME/.versions)")
 }
 
 // initConfig reads in config file and ENV variables if set.


### PR DESCRIPTION
Add a file to store version information for each file in burrito, the
file is specified by option '--versions', and default path is
'$HOME/.versions'.

Default page 'index.html' is redirected to the versions file, so version
information will be shown when following links are accessed:
  - http://<ip>:<port>
  - http://<ip>:<port>/index.html

**Reason for PR**:
<!-- What does this PR improve or fix? -->
The versions file is helpful to get version information for a binary file.

tests:

   - go build
   - ./burrito build --config=download_files.yaml --versions=file_versions.json
   - ./burrito serve --config=download_files.yaml --versions=file_versions.json
   - curl http://0.0.0.0:3000, version information is printed
   - curl http://0.0.0.0:3000/index.html, version information is printed
   - curl http://0.0.0.0:3000/files, file list is printed
   - curl http://0.0.0.0:3000/root, Not Found

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Issue #

**Requirements**

- [ ] Sqaush commits 
- [ ] Documentation
- [ ] Tests

**Notes**:

