### PR TITLE
fix(hostprocess): Use existing image for kube-proxy

### DIFF
--- a/hostprocess/calico/kube-proxy/kube-proxy.yml
+++ b/hostprocess/calico/kube-proxy/kube-proxy.yml
@@ -21,7 +21,7 @@ spec:
           runAsUserName: "NT AUTHORITY\\system"
       hostNetwork: true
       containers:
-      - image: sigwindowstools/kube-proxy:v1.21.1-calico-hostprocess
+      - image: sigwindowstools/kube-proxy:v1.22.3-calico-hostprocess
         args: ["$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/start.ps1"]
         workingDir: "$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/"
         name: kube-proxy


### PR DESCRIPTION
**Reason for PR**:
<!-- What does this PR improve or fix? -->
The image `sigwindowstools/kube-proxy:v1.21.1-calico-hostprocess` doesn't exist so I updated it to the newest existing one

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->


**Requirements**

- [✔] Sqaush commits 
- [ ] Documentation - not needed
- [ ] Tests - not needed

**Notes**:


