### PR TITLE
Add step to delete tmp.windows-containerd.tar.gz from windows-containerd-nightly release for nightly builds

### DIFF
--- a/.github/workflows/windows-containerd-nightly.yml
+++ b/.github/workflows/windows-containerd-nightly.yml
@@ -50,6 +50,16 @@ jobs:
         cd $GITHUB_WORKSPACE/output
         tar cvf windows-containerd.tar.gz bin
 
+    # sometimes eine/tip@master fails to upload release artifacts and this leaves
+    # a stale tmp file on the release which causes future runs of this workflow to fail.
+    - name: delete tmp.* release artifacts
+      uses: mknejp/delete-release-assets@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        tag: windows-containerd-nightly
+        fail-if-no-assests: false # do not fail if temp.windows-contaienrd.tar.gz does not exist
+        assets: tmp.windows-containerd.tar.gz
+
     - uses: eine/tip@master
       with:
         token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Hopefully this will help improve stability of the nightly containerd build

Signed-off-by: Mark Rossetti <marosset@microsoft.com>

**Reason for PR**:
<!-- What does this PR improve or fix? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Issue #

**Requirements**

- [ ] Sqaush commits 
- [ ] Documentation
- [ ] Tests

**Notes**:

/assign @jsturtevant 


