### PR TITLE
Use pwsh if available

### DIFF
--- a/kubeadm/flannel/setup.go
+++ b/kubeadm/flannel/setup.go
@@ -33,7 +33,13 @@ func setupL2bridge(interfaceName string) {
 }
 
 func run(command string) {
-	cmd := exec.Command("powershell", "-Command", command)
+	shell := "pwsh"
+	_, err := exec.LookPath(shell)
+	if err != nil {
+		shell = "powershell"
+	}
+
+	cmd := exec.Command(shell, "-Command", command)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
**Reason for PR**:
On `mcr.microsoft.com/powershell:lts-nanoserver-20h2` the PowerShell exe is `pwsh.exe` not `powershell.exe`. This image is much lighter than the alternate `windowsservercore` and is preferable for deployment to nodes running Windows 20h2.

**Notes**:
* Change is non-breaking since it will fallback to `powershell.exe`.
* nanoserver requires `netapi32.dll` to be copied from a matching `windowsservercore` image
* original source file has a mix of spaces and tabs
