### PR TITLE
Skip TLS verify on file download

### DIFF
--- a/burrito/Dockerfile
+++ b/burrito/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILDER_IMAGE=golang:1.16-alpine
+ARG BUILDER_IMAGE=golang:1.16
 ARG RUN_IMAGE=ubuntu:latest
 
 FROM ${BUILDER_IMAGE} as builder

--- a/burrito/cmd/build.go
+++ b/burrito/cmd/build.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"crypto/sha256"
+	"crypto/tls"
 	"fmt"
 	"io"
 	"log"
@@ -41,6 +42,7 @@ var buildCmd = &cobra.Command{
 	Read the specified config file and download the resources into the files 
 	sub directory.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 		for _, c := range mc.Components {
 			path, err := os.Getwd()
 			if err != nil {


### PR DESCRIPTION
To avoid the issue of "certificate signed by unknown authority"

**Reason for PR**:
<!-- What does this PR improve or fix? -->

golang-1.16 and ubuntu are used to replace golang:1.16-alpine and apline, they will check CA during file download, just skip the check.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Issue #

**Requirements**

- [ ] Sqaush commits 
- [ ] Documentation
- [ ] Tests

**Notes**:


