### PR TITLE
[do not merge] Move away from dockerhub and just use distroless (not working , yet)

### DIFF
--- a/burrito/Dockerfile
+++ b/burrito/Dockerfile
@@ -1,5 +1,5 @@
 ARG BUILDER_IMAGE=golang:1.16
-ARG RUN_IMAGE=ubuntu:latest
+ARG RUN_IMAGE=gcr.io/distroless/base-debian11
 
 FROM ${BUILDER_IMAGE} as builder
 


### PR DESCRIPTION
This is probably a better long term soln, smaller image, and no dockerhub rate limits

**Reason for PR**:
<!-- What does this PR improve or fix? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Issue #

**Requirements**

- [ ] Sqaush commits 
- [ ] Documentation
- [ ] Tests

**Notes**:


