### PR TITLE
fix Move-Item parameter and iface in flannel hostprocess

### DIFF
--- a/hostprocess/flannel/flanneld/start.ps1
+++ b/hostprocess/flannel/flanneld/start.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = "Stop";
 
 # flannel uses host-local, flannel.exe, and sdnoverlay so copy that to the correct location
 Write-Output "Moving SDN CNI binaries to host"
-Move-Item -Path "$env:CONTAINER_SANDBOX_MOUNT_POINT/cni/" -Destination "c:\opt\cni\bin" -Force
+Copy-Item -Path "$env:CONTAINER_SANDBOX_MOUNT_POINT/cni/" -Destination "c:\opt\cni\bin" -Force
 
 Write-Host "copy flannel config"
 mkdir -force C:\etc\kube-flannel\

--- a/hostprocess/flannel/flanneld/start.ps1
+++ b/hostprocess/flannel/flanneld/start.ps1
@@ -1,8 +1,8 @@
 $ErrorActionPreference = "Stop";
 
 # flannel uses host-local, flannel.exe, and sdnoverlay so copy that to the correct location
-Write-Output "Moving SDN CNI binaries to host"
-Copy-Item -Path "$env:CONTAINER_SANDBOX_MOUNT_POINT/cni/" -Destination "c:\opt\cni\bin" -Force
+Write-Output "Copying SDN CNI binaries to host"
+Copy-Item -Path "$env:CONTAINER_SANDBOX_MOUNT_POINT/cni/*" -Destination "c:\opt\cni\bin" -Force
 
 Write-Host "copy flannel config"
 mkdir -force C:\etc\kube-flannel\
@@ -39,4 +39,4 @@ write-host $env:POD_NAME
 write-host $env:POD_NAMESPACE
 
 Write-Host "Starting flannel"
-& $env:CONTAINER_SANDBOX_MOUNT_POINT/flannel/flanneld.exe --kube-subnet-mgr --kubeconfig-file $env:CONTAINER_SANDBOX_MOUNT_POINT/flannel-config-file/kubeconfig.conf --iface 10.1.0.5
+& $env:CONTAINER_SANDBOX_MOUNT_POINT/flannel/flanneld.exe --kube-subnet-mgr --kubeconfig-file $env:CONTAINER_SANDBOX_MOUNT_POINT/flannel-config-file/kubeconfig.conf --iface $managementIP

--- a/hostprocess/flannel/flanneld/start.ps1
+++ b/hostprocess/flannel/flanneld/start.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = "Stop";
 
 # flannel uses host-local, flannel.exe, and sdnoverlay so copy that to the correct location
 Write-Output "Moving SDN CNI binaries to host"
-Move-Item -Path "$env:CONTAINER_SANDBOX_MOUNT_POINT/cni/" -DestinationPath "c:\opt\cni\bin" -Force
+Move-Item -Path "$env:CONTAINER_SANDBOX_MOUNT_POINT/cni/" -Destination "c:\opt\cni\bin" -Force
 
 Write-Host "copy flannel config"
 mkdir -force C:\etc\kube-flannel\


### PR DESCRIPTION
**Reason for PR**:
Flannel in hostprocess mode fails with the following error:
```plaintext
$ kubectl -n kube-system logs -f kube-flannel-ds-windows-2022-amd64-kpnhk
Moving SDN CNI binaries to host
Move-Item : A parameter cannot be found that matches parameter name 'DestinationPath'.
At C:\C\2e81614228d3b72843d632b147666ae352759a67c6934ee8b0f058d5498ede26\flannel\start.ps1:5 char:59
+ ... th "$env:CONTAINER_SANDBOX_MOUNT_POINT/cni/" -DestinationPath "c:\opt ...
+                                                  ~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [Move-Item], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : NamedParameterNotFound,Microsoft.PowerShell.Commands.MoveItemCommand
```
This is because [Move-Item](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.management/move-item?view=powershell-7.2) contains no parameter named `DestinationPath` but has a parameter called `Destination`.
Also change `Move-Item` to `Copy-Item`, because the `CONTAINER_SANDBOX_MOUNT_POINT` access is denied (`Move-Item : Access to the path 'C:\C\5058c3fcf6266d2ba0c83cb8ce7dc4270e459f9ce470807bebf3f836a3182d2b\cni\' is denied.`).

Additionally the call to flanneld has a static iface IP set (10.1.0.5). This is changed now to the `$managementIP`.

This issue is also mentioned in #181

**Issue Fixed**:
Issue #181 partly

**Requirements**

- [ ] Sqaush commits 
- [ ] Documentation
- [ ] Tests

**Notes**:


