### PR TITLE
Add nightly build for hostprocess images

### DIFF
--- a/.github/workflows/hostprocess-images.yml
+++ b/.github/workflows/hostprocess-images.yml
@@ -1,0 +1,25 @@
+name: hostprocess-images
+
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    defaults:
+      run:
+        shell: pwsh
+        working-directory: ./hostprocess
+    steps:
+    - uses: actions/checkout@v2
+    - name: Prepare docker build
+      run: |
+        echo "${{ secrets.DOCKER_SECRET }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+        docker buildx create --name img-builder --use --platform windows/amd64
+    - name: Build and push images for calico
+      run: |
+        ./build-calico.ps1
+    - name: Build and push images for flannel
+      run: |
+        ./build-flannel.ps1

--- a/hostprocess/build-calico.ps1
+++ b/hostprocess/build-calico.ps1
@@ -1,0 +1,46 @@
+param(
+    [string]$repository = "sigwindowstools",
+    [version]$minCalicoVersion = "3.19.0",
+    [version]$minK8sVersion = "1.22.0"
+)
+
+pushd calico
+write-host "build calico"
+$calicoVersions = (curl -L https://api.github.com/repos/projectcalico/calico/releases | ConvertFrom-Json) | % tag_name
+foreach($calicoVersion in $calicoVersions)
+{
+    if ($calicoVersion -match "^v(\d+\.\d+\.\d+)$")
+    {
+        $testVersion = [version]$Matches[1]
+        if ($testVersion -ge $minCalicoVersion)
+        {
+            Write-Host "Build images for calico $calicoVersion"
+            pushd install
+            docker buildx build --platform windows/amd64 --output=type=registry --pull --build-arg=CALICO_VERSION=$calicoVersion -f Dockerfile.install -t $repository/calico-install:$calicoVersion-hostprocess .
+            popd
+            pushd node
+            docker buildx build --platform windows/amd64 --output=type=registry --pull --build-arg=CALICO_VERSION=$calicoVersion -f Dockerfile.node -t $repository/calico-node:$calicoVersion-hostprocess .
+            popd
+        }
+    }
+}
+
+
+write-host "build kube-proxy"
+pushd kube-proxy
+$versions = (curl -L k8s.gcr.io/v2/kube-proxy/tags/list | ConvertFrom-Json).tags
+foreach($version in $versions)
+{
+    if ($version -match "^v(\d+\.\d+\.\d+)$")
+    {
+        $testVersion = [version]$Matches[1]
+        if ($testVersion -ge $minK8sVersion)
+        {
+            Write-Host "Build image for kube-proxy $version"
+            docker buildx build --platform windows/amd64 --output=type=registry --pull --build-arg=k8sVersion=$version -f Dockerfile -t $repository/kube-proxy:$version-calico-hostprocess .
+        }
+    }
+}
+popd
+
+popd

--- a/hostprocess/build-flannel.ps1
+++ b/hostprocess/build-flannel.ps1
@@ -15,7 +15,7 @@ foreach($flannelVersion in $flannelVersions)
         $testVersion = [version]$Matches[1]
         if ($testVersion -ge $minFlannelVersion)
         {
-            Write-Host "Build images for flannel $calicoVersion"
+            Write-Host "Build images for flannel $flannelVersion"
             docker buildx build --platform windows/amd64 --output=type=registry --pull --build-arg=flannelVersion=$flannelVersion -f Dockerfile -t $repository/flannel:$flannelVersion-hostprocess .
         }
     }

--- a/hostprocess/build-flannel.ps1
+++ b/hostprocess/build-flannel.ps1
@@ -7,8 +7,8 @@ param(
 pushd flannel
 write-host "build flannel"
 pushd flanneld
-$calicoVersions = (curl -L https://api.github.com/repos/flannel-io/flannel/releases | ConvertFrom-Json) | % tag_name
-foreach($flannelVersion in $calicoVersions)
+$flannelVersions = (curl -L https://api.github.com/repos/flannel-io/flannel/releases | ConvertFrom-Json) | % tag_name
+foreach($flannelVersion in $flannelVersions)
 {
     if ($flannelVersion -match "^v(\d+\.\d+\.\d+)$")
     {

--- a/hostprocess/build-flannel.ps1
+++ b/hostprocess/build-flannel.ps1
@@ -1,0 +1,42 @@
+param(
+    [string]$repository = "sigwindowstools",
+    [version]$minFlannelVersion = "0.12.0",
+    [version]$minK8sVersion = "1.22.0"
+)
+
+pushd flannel
+write-host "build flannel"
+pushd flanneld
+$calicoVersions = (curl -L https://api.github.com/repos/flannel-io/flannel/releases | ConvertFrom-Json) | % tag_name
+foreach($flannelVersion in $calicoVersions)
+{
+    if ($flannelVersion -match "^v(\d+\.\d+\.\d+)$")
+    {
+        $testVersion = [version]$Matches[1]
+        if ($testVersion -ge $minFlannelVersion)
+        {
+            Write-Host "Build images for flannel $calicoVersion"
+            docker buildx build --platform windows/amd64 --output=type=registry --pull --build-arg=flannelVersion=$flannelVersion -f Dockerfile -t $repository/flannel:$flannelVersion-hostprocess .
+        }
+    }
+}
+popd
+
+write-host "build kube-proxy"
+pushd kube-proxy
+$versions = (curl -L k8s.gcr.io/v2/kube-proxy/tags/list | ConvertFrom-Json).tags
+foreach($version in $versions)
+{
+    if ($version -match "^v(\d+\.\d+\.\d+)$")
+    {
+        $testVersion = [version]$Matches[1]
+        if ($testVersion -ge $minK8sVersion)
+        {
+            Write-Host "Build image for kube-proxy $version"
+            docker buildx build --platform windows/amd64 --output=type=registry --pull --build-arg=k8sVersion=$version -f Dockerfile -t $repository/kube-proxy:$version-flannel-hostprocess .
+        }
+    }
+}
+popd
+
+popd


### PR DESCRIPTION
**Reason for PR**:
Add nightly build for hostprocess images:
- sigwindowstools/flannel:{flannelVersion}-hostprocess
- sigwindowstools/calico-install:{calicoVersion}-hostprocess
- sigwindowstools/calico-node:{calicoVersion}-hostprocess
- sigwindowstools/kube-proxy:{k8sVersion}-flannel-hostprocess
- sigwindowstools/kube-proxy:{k8sVersion}-calico-hostprocess

where:
- k8sVersion - all k8s versions from 1.22.0 (as min version that supports hostprocess)
- calicoVersion - all calico version from 3.19.0 (as min version that supports windows)
- flannelVersion - all flannel version from 0.12.0