### PR TITLE
Update log verbosity for kube-proxy image

### DIFF
--- a/hostprocess/build.sh
+++ b/hostprocess/build.sh
@@ -2,7 +2,6 @@
 
 repository=${repository:-"sigwindowstools"}
 flannelVersion=${flannelVersion:-"v0.14.0"}
-proxyVersion=${proxyVersion:-"v1.22.4"}
 calicoVersion=${calicoVersion:-"v3.20.0"}
 
 SCRIPTROOT=$(dirname "${BASH_SOURCE[0]}")
@@ -13,7 +12,7 @@ pushd $SCRIPTROOT/calico
 ./build.sh -r $repository --calicoVersion $calicoVersion
 popd
 
-declare -a proxyVersions=("v1.22.5" "v1.23.1")
+declare -a proxyVersions=("v1.22.5" "v1.23.0" "v1.23.1")
 
 # Read the array values with space
 for proxyVersion in "${proxyVersions[@]}"; do

--- a/hostprocess/calico/kube-proxy/start.ps1
+++ b/hostprocess/calico/kube-proxy/start.ps1
@@ -59,7 +59,7 @@ cp $env:CONTAINER_SANDBOX_MOUNT_POINT/var/lib/kube-proxy/kubeconfig.conf /var/li
 # Build up the arguments for starting kube-proxy.
 $argList = @(`
     "--hostname-override=$env:NODENAME", `
-    "--v=2",`
+    "--v=4",`
     "--proxy-mode=kernelspace",`
     "--kubeconfig=$env:CONTAINER_SANDBOX_MOUNT_POINT/var/lib/kube-proxy/kubeconfig.conf"`
 )


### PR DESCRIPTION
**Reason for PR**:
<!-- What does this PR improve or fix? -->
bumps the verbosity of kube-proxy image.  There is quite a bit of useful information in `v4` to debug issues but isn't as verbose as `-v6`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Issue #

**Requirements**

- [ ] Sqaush commits 
- [ ] Documentation
- [ ] Tests

**Notes**:


