### PR TITLE
update go to 1.17.5 for containerd-ightly

### DIFF
--- a/.github/workflows/windows-containerd-nightly.yml
+++ b/.github/workflows/windows-containerd-nightly.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.16.4
+        go-version: 1.17.5
     
     - name: Create drop folder
       run: mkdir -p $GITHUB_WORKSPACE/output/bin


### PR DESCRIPTION
Signed-off-by: Mark Rossetti <marosset@microsoft.com>

**Reason for PR**:
<!-- What does this PR improve or fix? -->
Updating golang version used in to build nightly of Windows containerd package to 1.17.5 to follow containred/containerd build version

xref - https://github.com/containerd/containerd/pull/6333 


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Issue #

**Requirements**

- [ ] Sqaush commits 
- [ ] Documentation
- [ ] Tests

**Notes**:


