### PR TITLE
Add support for Windows 20h2 and 2022

### DIFF
--- a/kubeadm/flannel/buildconfig.json
+++ b/kubeadm/flannel/buildconfig.json
@@ -5,6 +5,8 @@
     ],
     "baseimage": "mcr.microsoft.com/powershell",
     "tagsMap":[
+        {"source":"nanoserver-ltsc2022","target":"ltsc2022"},
+        {"source":"nanoserver-20h2","target":"20h2"},
         {"source":"nanoserver-2004","target":"2004"},
         {"source":"nanoserver-1909","target":"1909"},
         {"source":"nanoserver-1903","target":"1903"},

--- a/kubeadm/kube-proxy/buildconfig.json
+++ b/kubeadm/kube-proxy/buildconfig.json
@@ -1,6 +1,8 @@
 {
     "baseimage": "mcr.microsoft.com/powershell",
     "tagsMap":[
+        {"source":"nanoserver-ltsc2022","target":"ltsc2022"},
+        {"source":"nanoserver-20h2","target":"20h2"},
         {"source":"nanoserver-2004","target":"2004"},
         {"source":"nanoserver-1909","target":"1909"},
         {"source":"nanoserver-1903","target":"1903"},

--- a/kubeadm/scripts/PrepareNode.ps1
+++ b/kubeadm/scripts/PrepareNode.ps1
@@ -104,7 +104,7 @@ if ($global:containerRuntime -eq "Docker") {
     }
 }
 
-$cmd = "C:\k\kubelet.exe $global:KubeletArgs --cert-dir=$env:SYSTEMDRIVE\var\lib\kubelet\pki --config=/var/lib/kubelet/config.yaml --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf --hostname-override=$(hostname) --pod-infra-container-image=`"mcr.microsoft.com/oss/kubernetes/pause:1.4.1`" --enable-debugging-handlers --cgroups-per-qos=false --enforce-node-allocatable=`"`" --network-plugin=cni --resolv-conf=`"`" --log-dir=/var/log/kubelet --logtostderr=false --image-pull-progress-deadline=20m"
+$cmd = "C:\k\kubelet.exe $global:KubeletArgs --cert-dir=$env:SYSTEMDRIVE\var\lib\kubelet\pki --config=/var/lib/kubelet/config.yaml --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf --hostname-override=$(hostname) --pod-infra-container-image=`"mcr.microsoft.com/oss/kubernetes/pause:3.6`" --enable-debugging-handlers --cgroups-per-qos=false --enforce-node-allocatable=`"`" --network-plugin=cni --resolv-conf=`"`" --log-dir=/var/log/kubelet --logtostderr=false --image-pull-progress-deadline=20m"
 
 Invoke-Expression $cmd'
 $StartKubeletFileContent = $StartKubeletFileContent -replace "{{CONTAINER_RUNTIME}}", "`"$ContainerRuntime`""


### PR DESCRIPTION
**Reason for PR**:
I couldn't get flannel to work on my Windows Server 2022 (virtual machine). I noticed that the images were missing support for 20H2 and 2022. So here it's.

Notice: I'm not too sure if the version change of the pause image to 3.6 is fine, but it was needed for Windows Server 2022, since version 1.4.1 of the pause image isn't supported on 2022.

I pushed the updated container images for kube-proxy and flannel in my repositories:
https://hub.docker.com/r/mik4sa/kube-proxy
https://hub.docker.com/r/mik4sa/flannel


PS: I'm fairly new to the whole kubernetes world.