### PR TITLE
update latest version

### DIFF
--- a/hostprocess/build.sh
+++ b/hostprocess/build.sh
@@ -2,7 +2,7 @@
 
 repository=${repository:-"sigwindowstools"}
 flannelVersion=${flannelVersion:-"v0.14.0"}
-calicoVersion=${calicoVersion:-"v3.22.1"}
+calicoVersion=${calicoVersion:-"v3.23.0"}
 
 SCRIPTROOT=$(dirname "${BASH_SOURCE[0]}")
 pushd $SCRIPTROOT/flannel
@@ -12,7 +12,7 @@ pushd $SCRIPTROOT/calico
 ./build.sh -r $repository --calicoVersion $calicoVersion
 popd
 
-declare -a proxyVersions=("v1.22.8" "v1.23.5")
+declare -a proxyVersions=("v1.22.9" "v1.23.6" "v1.24.0")
 
 # Read the array values with space
 for proxyVersion in "${proxyVersions[@]}"; do


### PR DESCRIPTION
**Reason for PR**:
<!-- What does this PR improve or fix? -->
Adds latest kubernetes and calico versions. [Calico 3.23](https://projectcalico.docs.tigera.io/archive/v3.23/release-notes/) now has hostprocess support :partying_face:  so we will be dropping support for these files. 

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Issue #

**Requirements**

- [ ] Sqaush commits 
- [ ] Documentation
- [ ] Tests

**Notes**:


