### PR TITLE
Remove IPv6DualStack feature gate

### DIFF
--- a/kubeadm/kube-proxy/kube-proxy.yml
+++ b/kubeadm/kube-proxy/kube-proxy.yml
@@ -42,7 +42,6 @@ data:
     yq w -i /host/var/lib/kube-proxy/config.conf winkernel.sourceVip $sourceVip
     yq w -i /host/var/lib/kube-proxy/config.conf winkernel.networkName $networkName
     yq w -i /host/var/lib/kube-proxy/config.conf featureGates.WinOverlay true
-    yq w -i /host/var/lib/kube-proxy/config.conf featureGates.IPv6DualStack false
     yq w -i /host/var/lib/kube-proxy/config.conf mode "kernelspace"
     
     # Start the kube-proxy as a wins process on the host.


### PR DESCRIPTION
## PR Description

Remove `IPv6DualStack` feature gate. This is locked to `true` by default (and completely removed in 1.25)
