### PR TITLE
Remove feature gates in hostprocess kube-proxy script

### DIFF
--- a/hostprocess/flannel/kube-proxy/start.ps1
+++ b/hostprocess/flannel/kube-proxy/start.ps1
@@ -61,7 +61,6 @@ Write-Host "sourceip: $vip"
 
 $arguements = "--v=6",
         "--hostname-override=$env:NODE_NAME",
-        "--feature-gates=WinOverlay=true,IPv6DualStack=false",
         "--proxy-mode=kernelspace",
         "--source-vip=$vip",  
         "--kubeconfig=$env:CONTAINER_SANDBOX_MOUNT_POINT/var/lib/kube-proxy/kubeconfig.conf"


### PR DESCRIPTION
**Reason for PR**:
<!-- What does this PR improve or fix? -->
Removes feature gates in the kube-proxy hostprocess script: 

- winOverlay which is set to true since 1.20
- IPv6DualStack which is GA since 1.23





