### PR TITLE
setting version for containerd nightly package to 1.7.0+unknown so wecan differenite between v1.6 and v1.7 in tests

### DIFF
--- a/.github/workflows/windows-containerd-nightly.yml
+++ b/.github/workflows/windows-containerd-nightly.yml
@@ -37,6 +37,7 @@ jobs:
       env:
         GOOS: windows
         GOARCH: amd64
+        VERSION: v1.7.0+unknown
       run: |
         git clone https://github.com/containerd/containerd.git
         cd containerd


### PR DESCRIPTION


Signed-off-by: Mark Rossetti <marosset@microsoft.com>

**Reason for PR**:
<!-- What does this PR improve or fix? -->
We need to be able to detect if we are running on containerd v1.6 or v1.7 for some K8s e2e tests.
This PR updates the nightly build of containerd to report a v1.7 version.



**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Issue #

**Requirements**

- [ ] Sqaush commits 
- [ ] Documentation
- [ ] Tests

**Notes**:


