### PR TITLE
Updated build version to v1.22.0

### DIFF
--- a/kubeadm/kube-proxy/build.ps1
+++ b/kubeadm/kube-proxy/build.ps1
@@ -1,7 +1,7 @@
 param(
     [string]$image = "sigwindowstools/kube-proxy",
     [switch]$push,
-    [version]$minVersion = "1.17.0"
+    [version]$minVersion = "1.22.0"
 )
 
 $output="docker"


### PR DESCRIPTION
Updated kube-proxy build to minVersion 1.22.0 from 1.17.0

**Reason for PR**:
Updated build.ps1 minVersion to 1.22.0 from 1.17.0 because they are not supported anymore.
([https://endoflife.date/kubernetes](https://endoflife.date/kubernetes?fbclid=IwAR3TcFBgjCzBgNjDW4s2qrMTJaxxCTGsgtV4iiC16xE8L0FxhNTs57lfa2k))