### PR TITLE
Making script more self-explanatory

### DIFF
--- a/kubeadm/scripts/PrepareNode.ps1
+++ b/kubeadm/scripts/PrepareNode.ps1
@@ -15,7 +15,7 @@ Kubernetes version to download and use
 Container that Kubernetes will use. (Docker or containerD)
 
 .EXAMPLE
-PS> .\PrepareNode.ps1 -KubernetesVersion v1.19.3 -ContainerRuntime containerD
+PS> .\PrepareNode.ps1 -KubernetesVersion v1.24.2 -ContainerRuntime containerD
 
 #>
 
@@ -91,6 +91,15 @@ mkdir -force C:\var\lib\kubelet\etc\kubernetes
 mkdir -force C:\etc\kubernetes\pki
 New-Item -path C:\var\lib\kubelet\etc\kubernetes\pki -type SymbolicLink -value C:\etc\kubernetes\pki\
 
+# dockershim related flags (--image-pull-progress-deadline=20m and --network-plugin=cni)  are removed in k8s v1.24
+# Link to changelog: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md
+
+$cmd_commands=@("C:\k\kubelet.exe ", '$global:KubeletArgs ', '--cert-dir=$env:SYSTEMDRIVE\var\lib\kubelet\pki ', "--config=/var/lib/kubelet/config.yaml ", "--bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf ", "--kubeconfig=/etc/kubernetes/kubelet.conf ", '--hostname-override=$(hostname) ', '--pod-infra-container-image=`"mcr.microsoft.com/oss/kubernetes/pause:3.6`" ', "--enable-debugging-handlers ", "--cgroups-per-qos=false ", '--enforce-node-allocatable=`"`" ', '--resolv-conf=`"`" ', "--log-dir=/var/log/kubelet ", "--logtostderr=false ")
+[version]$CurrentVersion = $($KubernetesVersion.Split("v") | Select -Index 1)
+[version]$V1_24_Version = '1.24'
+if ($CurrentVersion -lt $V1_24_Version) {
+    $cmd_commands = $cmd_commands + "--network-plugin=cni " + "--image-pull-progress-deadline=20m "
+}
 $StartKubeletFileContent = '$FileContent = Get-Content -Path "/var/lib/kubelet/kubeadm-flags.env"
 $global:KubeletArgs = $FileContent.TrimStart(''KUBELET_KUBEADM_ARGS='').Trim(''"'')
 
@@ -104,8 +113,7 @@ if ($global:containerRuntime -eq "Docker") {
     }
 }
 
-$cmd = "C:\k\kubelet.exe $global:KubeletArgs --cert-dir=$env:SYSTEMDRIVE\var\lib\kubelet\pki --config=/var/lib/kubelet/config.yaml --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf --hostname-override=$(hostname) --pod-infra-container-image=`"mcr.microsoft.com/oss/kubernetes/pause:3.6`" --enable-debugging-handlers --cgroups-per-qos=false --enforce-node-allocatable=`"`" --network-plugin=cni --resolv-conf=`"`" --log-dir=/var/log/kubelet --logtostderr=false --image-pull-progress-deadline=20m"
-
+$cmd = "' + $cmd_commands + '"
 Invoke-Expression $cmd'
 $StartKubeletFileContent = $StartKubeletFileContent -replace "{{CONTAINER_RUNTIME}}", "`"$ContainerRuntime`""
 Set-Content -Path $global:StartKubeletScript -Value $StartKubeletFileContent
@@ -137,3 +145,25 @@ if ($ContainerRuntime -eq "Docker") {
 }
 
 New-NetFirewallRule -Name kubelet -DisplayName 'kubelet' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 10250
+
+Write-Output "Please remember that after you have joined the node to the cluster, that you have to apply the cni daemonset/service and the kube-proxy"
+Write-Output "Also remember that for kube-proxy you have to change the its version from the name of the image in the kube-proxy.yml to that of your kubernetes version `n"
+# rancher commands
+Write-Output "In case you use rancher, use the following commands:"
+Write-Output "For Windows you can use the following command: "
+Write-Output "(Get-Content `"$(git rev-parse --show-toplevel)/kubeadm/kube-proxy/kube-proxy.yml`") -Replace 'VERSION', '$KubernetesVersion' | Set-Content `"$(git rev-parse --show-toplevel)/kubeadm/kube-proxy/kube-proxy.yml`" `n"
+Write-Output "For Linux, you can use the following command: "
+Write-Output "sed -i 's/VERSION/$KubernetesVersion/g' `$(find `$(git rev-parse --show-toplevel) -iname 'kube-proxy.yml' | grep kubeadm)`n"
+# flannel commands
+Write-Output "In case you use flannel, use the following commands:"
+Write-Output "For Windows you can use the following command: "
+Write-Output "(Get-Content `"$(git rev-parse --show-toplevel)/hostprocess/flannel/kube-proxy/kube-proxy.yml`") -Replace 'image: (.*):(.*)-(.*)-(.*)$', 'image: `$1:$KubernetesVersion-`$3-`$4' | Set-Content `"$(git rev-parse --show-toplevel)/hostprocess/flannel/kube-proxy/kube-proxy.yml`" `n"
+Write-Output "For Linux, you can use the following command: "
+Write-Output "sed -i -E 's/image: (.*):(.*)-(.*)-(.*)$/image: \1:$KubernetesVersion-\3-\4/g' `$(find `$(git rev-parse --show-toplevel) -iname 'kube-proxy.yml' | grep flannel)`n"
+# calico commands
+Write-Output "In case you use calico, use the following commands:"
+Write-Output "For Windows you can use the following command: "
+Write-Output "(Get-Content `"$(git rev-parse --show-toplevel)/hostprocess/calico/kube-proxy/kube-proxy.yml`") -Replace 'image: (.*):(.*)-(.*)-(.*)$', 'image: `$1:$KubernetesVersion-`$3-`$4' | Set-Content `"$(git rev-parse --show-toplevel)/hostprocess/calico/kube-proxy/kube-proxy.yml`" `n"
+Write-Output "For Linux, you can use the following command: "
+# - image: sigwindowstools/kube-proxy:v1.24.2-flannel-hostprocess
+Write-Output "sed -i -E 's/image: (.*):(.*)-(.*)-(.*)$/image: \1:$KubernetesVersion-\3-\4/g' `$(find `$(git rev-parse --show-toplevel) -iname 'kube-proxy.yml' | grep calico)`n"


### PR DESCRIPTION
**Reason for PR**:
Making script more self-explanatory for users because after joining the node they also have to apply the cni daemonset/service and the kube-proxy and they have to change the k8s version of the kube-proxy.yml file to match their own.

All kube-proxy.yml files in the repository have different versions of k8s set to their containers` images and the user need to manually configure them to match its own version of kubernetes.
**For calico**, kube-proxy image is " - image: sigwindowstools/kube-proxy:**v1.22.3**-calico-hostprocess"
**For rancher**, kube-proxy image is "image: sigwindowstools/kube-proxy:VERSION-nanoserver"
**For flannel**, kube-proxy image is "- image: sigwindowstools/kube-proxy:v1.22.4-flannel-hostprocess"

It is not self-explanatory and this might cause problems to users.


