### PR TITLE
Updates hostprocess kube proxy build script

### DIFF
--- a/hostprocess/build.sh
+++ b/hostprocess/build.sh
@@ -1,8 +1,22 @@
 #!/bin/bash
+<<'DESCRIPTION'
+  Script to build flannel and callico versions as well as their kube-proxy versions
+  There is also the posibility to build only a specific kube-proxy image or change the repository
+  and flannel/calico versions via the environment variables in the script,
+  in order to build it for other versions of them
+  
+  .EXAMPLE
+  ./build.sh --kubeProxyVersion v1.24.3
+  ./build.sh --kubeProxyVersion v1.24.3 -r sigwindowstools --flannelVersion v0.14.0
+  ./build.sh --kubeProxyVersion v1.24.3 -r sigwindowstools --calicoVersion v3.23.0
+
+DESCRIPTION
 
 repository=${repository:-"sigwindowstools"}
 flannelVersion=${flannelVersion:-"v0.14.0"}
-calicoVersion=${calicoVersion:-"v3.23.3"}
+calicoVersion=${calicoVersion:-"v3.23.0"}
+kubeProxyVersion=${kubeProxyVersion:-""}
+minVersion=${minVersion:-"v1.23.0"}
 
 SCRIPTROOT=$(dirname "${BASH_SOURCE[0]}")
 pushd $SCRIPTROOT/flannel
@@ -12,14 +26,24 @@ pushd $SCRIPTROOT/calico
 ./build.sh -r $repository --calicoVersion $calicoVersion
 popd
 
-declare -a proxyVersions=("v1.22.17" "v1.23.15" "v1.24.9" "v1.25.5" "v1.26.0")
+declare -a proxyVersions=($(curl -L registry.k8s.io/v2/kube-proxy/tags/list | jq .tags | tr "\n" " " | tr -d '"' | tr -d ','))
+
+if [ -n "$kubeProxyVersion" ]
+then
+  proxyVersions=("$kubeProxyVersion")
+fi
 
 # Read the array values with space
 for proxyVersion in "${proxyVersions[@]}"; do
-  pushd $SCRIPTROOT/flannel
-  ./build.sh -r $repository --proxyVersion $proxyVersion
-  popd
-  pushd $SCRIPTROOT/calico
-  ./build.sh -r $repository --proxyVersion $proxyVersion
-  popd
+  if [[ "$proxyVersion" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ && $minVersion == `echo -e "$minVersion\n$proxyVersion" | sort -V | head -n1` ]]
+  then
+    echo "Building flannel proxy version $proxyVersion"
+    pushd $SCRIPTROOT/flannel
+    ./build.sh -r $repository --proxyVersion $proxyVersion
+    popd
+    echo "Building calico proxy version $proxyVersion"
+    pushd $SCRIPTROOT/calico
+    ./build.sh -r $repository --proxyVersion $proxyVersion
+    popd
+  fi
 done


### PR DESCRIPTION
**Reason for PR**:
Updated the hostprocess kube-proxy build script in order to be able to build all kube-proxy versions above v1.23.0 and added the possibility to build only a specific version of kube-proxy

