### PR TITLE
Adding a GH action to ensure we have build all versions of Windows kube-proxy image

### DIFF
--- a/.github/workflows/test-kube-proxy-images.yaml
+++ b/.github/workflows/test-kube-proxy-images.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: test-kube-proxy-images
+
+on:
+  schedule:
+    - cron: '0 2 * * *' # Every day at 02:00 UTC
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Run script
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Test kube-proxy images
+      run: powershell.exe ./hack/test-kube-proxy-images.ps1

--- a/hack/test-kube-proxy-images.ps1
+++ b/hack/test-kube-proxy-images.ps1
@@ -1,0 +1,36 @@
+param (
+    [string]$minK8sVersion = "v1.22"
+)
+
+# Get kube-proxy images
+$content = curl.exe -L registry.k8s.io/v2/kube-proxy/tags/list
+$json = ConvertFrom-Json $content
+
+$missingKubeProxyImages = @()
+
+foreach ($tag in $json.tags) {
+    if (-not($tag.StartsWith("v"))) {
+        continue
+    }
+    if ($tag.Contains("-")) {
+        continue
+    }
+    if ([Version]($tag.TrimStart('v')) -lt [Version]($minK8sVersion.TrimStart('v'))) {
+        continue
+    }
+
+    foreach ($flavor in @("-calico-hostprocess", "-flannel-hostprocess")) {
+        $image = "sigwindowstools/kube-proxy:$tag$flavor"
+        Write-Output "Checking for image $image"
+        docker manifest inspect $image | Out-Null
+        if ($LastExitCode -ne 0) {
+            $missingKubeProxyimages += $image
+            Write-Output "  Image $image is missing!"
+        }
+    }
+}
+
+if ($missingKubeProxyImages.Length -gt 0) {
+    Write-Output "Found ${$missingKubeProxyImages.Length} missing images!"
+    exit 1
+}


### PR DESCRIPTION


Signed-off-by: Mark Rossetti <marosset@microsoft.com>

**Reason for PR**:
<!-- What does this PR improve or fix? -->
Adding a github action to ensure we have build Windows kube-proxy images for all applicable K8s versions.

I have this running in my fork and it is correctly failing b/c of missing v1.22.0 images 

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Issue #

**Requirements**

- [ ] Sqaush commits 
- [ ] Documentation
- [ ] Tests

**Notes**:

/assign @jsturtevant @fabi200123 
