### PR TITLE
Scripts update to make them usable with hostprocess model

### DIFF
--- a/kubeadm/scripts/Install-Containerd.ps1
+++ b/kubeadm/scripts/Install-Containerd.ps1
@@ -11,6 +11,7 @@ This script
 
 .PARAMETER ContainerDVersion
 ContainerD version to download and use.
+For HostProcess containers minimal version is 1.6.0.
 
 .PARAMETER netAdapterName
 Name of network adapter to use when configuring basic nat network.
@@ -20,6 +21,9 @@ Declares that HostProcess model is in use. Some code should be omitted.
 
 .EXAMPLE
 PS> .\Install-Conatinerd.ps1
+
+.EXAMPLE
+PS> .\Install-Containerd.ps1 -UseHostProcess -ContainerDVersion # 1.6.0+
 
 #>
 
@@ -79,6 +83,16 @@ if (-not (ValidateWindowsFeatures)) {
 
     Write-Output "Please reboot and re-run this script."
     exit 0
+}
+
+if ($UseHostProcess.IsPresent) {
+    $minimalVersion = [version]::new(1, 6, 0)
+    if ([version]::new($ContainerDVersion) -lt $minimalVersion) {
+        Write-Error `
+            ("Incompatible ContainerD version $ContainerDVersion requested. " +
+            "Minimal required version is $minimalVersion.")
+        exit 1
+    }
 }
 
 Write-Output "Getting ContainerD binaries"

--- a/kubeadm/scripts/Install-Containerd.ps1
+++ b/kubeadm/scripts/Install-Containerd.ps1
@@ -15,16 +15,30 @@ ContainerD version to download and use.
 .PARAMETER netAdapterName
 Name of network adapter to use when configuring basic nat network.
 
+.PARAMETER UseHostProcess
+Declares that HostProcess model is in use. Some code should be omitted.
+
 .EXAMPLE
 PS> .\Install-Conatinerd.ps1
 
 #>
 
+[CmdletBinding(
+    DefaultParameterSetName="kubeadm"
+)]
 Param(
     [parameter(HelpMessage = "ContainerD version to use")]
     [string] $ContainerDVersion = "1.6.8",
-    [parameter(HelpMessage = "Name of network adapter to use when configuring basic nat network")]
-    [string] $netAdapterName = "Ethernet"
+    [parameter(
+        HelpMessage = "Name of network adapter to use when configuring basic nat network",
+        ParameterSetName = "kubeadm"
+    )]
+    [string] $netAdapterName = "Ethernet",
+    [parameter(
+        HelpMessage = "Declares that HostProcess model is in use",
+        ParameterSetName = "hostprocess"
+    )]
+    [switch] $UseHostProcess
 )
 
 $ErrorActionPreference = 'Stop'

--- a/kubeadm/scripts/PrepareNode.ps1
+++ b/kubeadm/scripts/PrepareNode.ps1
@@ -17,6 +17,7 @@ Container that Kubernetes will use. (Docker or containerD)
 
 .PARAMETER UseHostProcess
 Declares that HostProcess model is in use. Some code should be omitted.
+ContainerD usage is forced.
 
 .PARAMETER SuppressHints
 Suppresses hints at the end of work.
@@ -30,13 +31,22 @@ PS> .\PrepareNode.ps1 -UseHostProcess -KubernetesVersion # v1.23.0+
 
 #>
 
+[CmdletBinding(
+    DefaultParameterSetName="kubeadm"
+)]
 Param(
     [parameter(Mandatory = $true, HelpMessage="Kubernetes version to use")]
     [string] $KubernetesVersion,
-    [parameter(HelpMessage="Container runtime that Kubernets will use")]
+    [parameter(
+        HelpMessage="Container runtime that Kubernets will use",
+        ParameterSetName="kubeadm"
+    )]
     [ValidateSet("containerD", "Docker")]
     [string] $ContainerRuntime = "Docker",
-    [parameter(HelpMessage="Declares that HostProcess model is in use")]
+    [parameter(
+        HelpMessage="Declares that HostProcess model is in use",
+        ParameterSetName="hostprocess"
+    )]
     [switch] $UseHostProcess,
     [parameter(HelpMessage="Suppresses hints at the end of work")]
     [switch] $SuppressHints
@@ -61,6 +71,7 @@ if ($UseHostProcess.IsPresent) {
             "Minimal required version is $minimalVersion.")
         exit 1
     }
+    $ContainerRuntime = "containerD"
 }
 
 if ($ContainerRuntime -eq "Docker") {

--- a/kubeadm/scripts/PrepareNode.ps1
+++ b/kubeadm/scripts/PrepareNode.ps1
@@ -22,6 +22,7 @@ ContainerD usage is forced.
 .PARAMETER SuppressHints
 Suppresses hints at the end of work.
 This little help introduce dependency on git to build copy/paste-able code snippets.
+Flag presence makes this script free of that when you need it.
 
 .EXAMPLE
 PS> .\PrepareNode.ps1 -KubernetesVersion v1.24.2 -ContainerRuntime containerD
@@ -29,6 +30,8 @@ PS> .\PrepareNode.ps1 -KubernetesVersion v1.24.2 -ContainerRuntime containerD
 .EXAMPLE
 PS> .\PrepareNode.ps1 -UseHostProcess -KubernetesVersion # v1.23.0+
 
+Please note, there is no reason to give a choice for a container runtime in this case.
+ContainerD runtime will be used forcibly.
 #>
 
 [CmdletBinding(

--- a/kubeadm/scripts/PrepareNode.ps1
+++ b/kubeadm/scripts/PrepareNode.ps1
@@ -10,6 +10,7 @@ This script assists with joining a Windows node to a cluster.
 
 .PARAMETER KubernetesVersion
 Kubernetes version to download and use
+For HostProcess containers minimal version is 1.23.0.
 
 .PARAMETER ContainerRuntime
 Container that Kubernetes will use. (Docker or containerD)
@@ -23,6 +24,9 @@ This little help introduce dependency on git to build copy/paste-able code snipp
 
 .EXAMPLE
 PS> .\PrepareNode.ps1 -KubernetesVersion v1.24.2 -ContainerRuntime containerD
+
+.EXAMPLE
+PS> .\PrepareNode.ps1 -UseHostProcess -KubernetesVersion # v1.23.0+
 
 #>
 
@@ -45,6 +49,16 @@ function DownloadFile($destination, $source) {
 
     if (!$?) {
         Write-Error "Download $source failed"
+        exit 1
+    }
+}
+
+if ($UseHostProcess.IsPresent) {
+    $minimalVersion = [version]::new(1, 23, 0)
+    if ([version]::new($KubernetesVersion) -lt $minimalVersion) {
+        Write-Error `
+            ("Incompatible Kubernetes version $KubernetesVersion requested. " +
+            "Minimal required version is $minimalVersion.")
         exit 1
     }
 }


### PR DESCRIPTION
**Reason for PR**:
It seems that `Install-Container.ps1` and `PrepareNode.ps1` may be useful to build a Windows node with HostProcess containers and k8s 1.25.3 at least. But some changes are needed because some code does not cooperate. This commit is a proposal to leave the current code unchanged for backward compatibility and introduce the _UseHostProcess_ parameter to handle code not needed to support HostProcess containers where are engaged.

**Requirements**

- [x] Squash commits 

**Notes**:
There are also changes beyond the main reason. When the UseHostProcess flag is present, the script makes asserts on Kubernetes and ContainerD versions to announce incompatibilities. Another improvement is to not have a choice of container runtime when HostProcess is in use.

Additionally, it offers the _SuppressHints_ parameter to have the option to omit on demand some help messages. Omitted code depends on the git tool installed. It may be an optimization for automated node provisioning (eg. vagrant) and saves some time wasted for git install and repository cloning.


