### PR TITLE
Removing SAC releases from non-hostprocess images

### DIFF
--- a/kubeadm/flannel/buildconfig.json
+++ b/kubeadm/flannel/buildconfig.json
@@ -8,10 +8,6 @@
     "baseimage": "mcr.microsoft.com/powershell",
     "tagsMap":[
         {"source":"nanoserver-ltsc2022","target":"ltsc2022"},
-        {"source":"nanoserver-20h2","target":"20h2"},
-        {"source":"nanoserver-2004","target":"2004"},
-        {"source":"nanoserver-1909","target":"1909"},
-        {"source":"nanoserver-1903","target":"1903"},
         {"source":"nanoserver-1809","target":"1809"}
     ]
 }

--- a/kubeadm/kube-proxy/buildconfig.json
+++ b/kubeadm/kube-proxy/buildconfig.json
@@ -2,10 +2,6 @@
     "baseimage": "mcr.microsoft.com/powershell",
     "tagsMap":[
         {"source":"nanoserver-ltsc2022","target":"ltsc2022"},
-        {"source":"nanoserver-20h2","target":"20h2"},
-        {"source":"nanoserver-2004","target":"2004"},
-        {"source":"nanoserver-1909","target":"1909"},
-        {"source":"nanoserver-1903","target":"1903"},
         {"source":"nanoserver-1809","target":"1809"}
     ]
 }


### PR DESCRIPTION
Signed-off-by: Mark Rossetti <marosset@microsoft.com>

**Reason for PR**:
<!-- What does this PR improve or fix? -->
All Windows SAC releases are deprecated.


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Issue #

**Requirements**

- [ ] Sqaush commits 
- [ ] Documentation
- [ ] Tests

**Notes**:


