### PR TITLE
Running kubelet v1.26 fixes (deprecated args)

### DIFF
--- a/kubeadm/scripts/PrepareNode.ps1
+++ b/kubeadm/scripts/PrepareNode.ps1
@@ -94,12 +94,17 @@ New-Item -path C:\var\lib\kubelet\etc\kubernetes\pki -type SymbolicLink -value C
 # dockershim related flags (--image-pull-progress-deadline=20m and --network-plugin=cni)  are removed in k8s v1.24
 # Link to changelog: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md
 
-$cmd_commands=@("C:\k\kubelet.exe ", '$global:KubeletArgs ', '--cert-dir=$env:SYSTEMDRIVE\var\lib\kubelet\pki ', "--config=/var/lib/kubelet/config.yaml ", "--bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf ", "--kubeconfig=/etc/kubernetes/kubelet.conf ", '--hostname-override=$(hostname) ', '--pod-infra-container-image=`"mcr.microsoft.com/oss/kubernetes/pause:3.6`" ', "--enable-debugging-handlers ", "--cgroups-per-qos=false ", '--enforce-node-allocatable=`"`" ', '--resolv-conf=`"`" ', "--log-dir=/var/log/kubelet ", "--logtostderr=false ")
+$cmd_commands=@("C:\k\kubelet.exe ", '$global:KubeletArgs ', '--cert-dir=$env:SYSTEMDRIVE\var\lib\kubelet\pki ', "--config=/var/lib/kubelet/config.yaml ", "--bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf ", "--kubeconfig=/etc/kubernetes/kubelet.conf ", '--hostname-override=$(hostname) ', '--pod-infra-container-image=`"mcr.microsoft.com/oss/kubernetes/pause:3.6`" ', "--enable-debugging-handlers ", "--cgroups-per-qos=false ", '--enforce-node-allocatable=`"`" ', '--resolv-conf=`"`" ')
 [version]$CurrentVersion = $($KubernetesVersion.Split("v") | Select -Index 1)
 [version]$V1_24_Version = '1.24'
 if ($CurrentVersion -lt $V1_24_Version) {
     $cmd_commands = $cmd_commands + "--network-plugin=cni " + "--image-pull-progress-deadline=20m "
 }
+[version]$V1_26_Version = '1.26'
+if ($CurrentVersion -lt $V1_26_Version) {
+    $cmd_commands += ("--log-dir=/var/log/kubelet ", "--logtostderr=false ")
+}
+
 $StartKubeletFileContent = '$FileContent = Get-Content -Path "/var/lib/kubelet/kubeadm-flags.env"
 $global:KubeletArgs = $FileContent.TrimStart(''KUBELET_KUBEADM_ARGS='').Trim(''"'')
 


### PR DESCRIPTION

**Reason for PR**:
Deprecated arguments removed: --log-dir=/var/log/kubelet --logtostderr=false


**Requirements**

- [x] Sqaush commits 
