### PR TITLE
Updating Windows Scripts

### DIFF
--- a/guides/guide-for-adding-windows-node.md
+++ b/guides/guide-for-adding-windows-node.md
@@ -91,8 +91,7 @@ Now you can add Windows-compatible versions of Flannel and kube-proxy. In order 
 
 ```bash
 curl -L https://github.com/kubernetes-sigs/sig-windows-tools/releases/latest/download/kube-proxy.yml | sed 's/KUBE_PROXY_VERSION/v1.25.3/g' | kubectl apply -f -
-curl -L https://raw.githubusercontent.com/kubernetes-sigs/sig-windows-tools/master/hostprocess/flannel/flanneld/flannel-overlay.yml | sed 's/FLANNEL_VERSION/v0.14.0/g' | kubectl apply -f -
-kubectl apply -f https://github.com/kubernetes-sigs/sig-windows-tools/releases/latest/download/flannel-overlay.yml
+curl -L https://raw.githubusercontent.com/kubernetes-sigs/sig-windows-tools/master/hostprocess/flannel/flanneld/flannel-overlay.yml | sed 's/FLANNEL_VERSION/v0.17.0/g' | kubectl apply -f -
 ```
 
 >  **Note** If you are using another version of kubernetes on your Windows node, change v1.25.3 with your own version .
@@ -103,7 +102,7 @@ kubectl apply -f https://github.com/kubernetes-sigs/sig-windows-tools/releases/l
 Next you will need to apply the configuration that allows flannel to spawn pods and keep them running:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/sig-windows-tools/master/kubeadm/flannel/kube-flannel-rbac.yml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/sig-windows-tools/master/hostprocess/flannel/flanneld/kube-flannel-rbac.yml
 ```
 
 

--- a/hostprocess/calico/calico.yml
+++ b/hostprocess/calico/calico.yml
@@ -131,7 +131,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: sigwindowstools/calico-install:VERSION-hostprocess
+          image: sigwindowstools/calico-install:CALICO_VERSION-hostprocess
           args: ["$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/install.ps1"]
           imagePullPolicy: Always
           env:
@@ -173,7 +173,7 @@ spec:
               runAsUserName: "NT AUTHORITY\\system"
       containers:
       - name: calico-node-startup
-        image: sigwindowstools/calico-node:VERSION-hostprocess
+        image: sigwindowstools/calico-node:CALICO_VERSION-hostprocess
         args: ["$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/node-service.ps1"]
         workingDir: "$env:CONTAINER_SANDBOX_MOUNT_POINT/calico/"
         imagePullPolicy: Always

--- a/kubeadm/scripts/Install-Containerd.ps1
+++ b/kubeadm/scripts/Install-Containerd.ps1
@@ -81,17 +81,10 @@ $config = $config -replace "bin_dir = (.)*$", "bin_dir = `"c:/opt/cni/bin`""
 $config = $config -replace "conf_dir = (.)*$", "conf_dir = `"c:/etc/cni/net.d`""
 $config | Set-Content "$global:ConainterDPath\config.toml" -Force 
 
-mkdir -Force c:\opt\cni\bin | Out-Null
-mkdir -Force c:\etc\cni\net.d | Out-Null
-
-Write-Output "Getting SDN CNI binaries"
-DownloadFile "c:\opt\cni\cni-plugins.zip" https://github.com/microsoft/windows-container-networking/releases/download/v0.2.0/windows-container-networking-cni-amd64-v0.2.0.zip
-Expand-Archive -Path "c:\opt\cni\cni-plugins.zip" -DestinationPath "c:\opt\cni\bin" -Force
-
 Write-Output "Registering ContainerD as a service"
 containerd.exe --register-service
 
 Write-Output "Starting ContainerD service"
 Start-Service containerd
 
-Write-Output "Done - please remember to add '--cri-socket `"npipe:////./pipe/containerd-containerd`"' to your kubeadm join command"
+Write-Output "Done - please remember to add '--cri-socket `"npipe:////./pipe/containerd-containerd`"' to your kubeadm join command if your kubernetes version is below 1.25!"

--- a/kubeadm/scripts/PrepareNode.ps1
+++ b/kubeadm/scripts/PrepareNode.ps1
@@ -11,20 +11,14 @@ This script assists with joining a Windows node to a cluster.
 .PARAMETER KubernetesVersion
 Kubernetes version to download and use
 
-.PARAMETER ContainerRuntime
-Container that Kubernetes will use. (Docker or containerD)
-
 .EXAMPLE
-PS> .\PrepareNode.ps1 -KubernetesVersion v1.24.2 -ContainerRuntime containerD
+PS> .\PrepareNode.ps1 -KubernetesVersion v1.25.3
 
 #>
 
 Param(
     [parameter(Mandatory = $true, HelpMessage="Kubernetes version to use")]
-    [string] $KubernetesVersion,
-    [parameter(HelpMessage="Container runtime that Kubernets will use")]
-    [ValidateSet("containerD", "Docker")]
-    [string] $ContainerRuntime = "Docker"
+    [string] $KubernetesVersion
 )
 $ErrorActionPreference = 'Stop'
 
@@ -38,16 +32,9 @@ function DownloadFile($destination, $source) {
     }
 }
 
-if ($ContainerRuntime -eq "Docker") {
-    if (-not(Test-Path "//./pipe/docker_engine")) {
-        Write-Error "Docker service was not detected - please install start Docker before calling PrepareNode.ps1 with -ContainerRuntime Docker"
-        exit 1
-    }
-} elseif ($ContainerRuntime -eq "containerD") {
-    if (-not(Test-Path "//./pipe/containerd-containerd")) {
-        Write-Error "ContainerD service was not detected - please install and start containerD before calling PrepareNode.ps1 with -ContainerRuntime containerD"
-        exit 1
-    }
+if (-not(Test-Path "//./pipe/containerd-containerd")) {
+    Write-Error "ContainerD service was not detected - please install and start containerD before calling PrepareNode.ps1 with -ContainerRuntime containerD"
+    exit 1
 }
 
 if (!$KubernetesVersion.StartsWith("v")) {
@@ -67,24 +54,6 @@ $env:Path += ";$global:KubernetesPath"
 
 DownloadFile $kubeletBinPath https://dl.k8s.io/$KubernetesVersion/bin/windows/amd64/kubelet.exe
 DownloadFile "$global:KubernetesPath\kubeadm.exe" https://dl.k8s.io/$KubernetesVersion/bin/windows/amd64/kubeadm.exe
-DownloadFile "$global:KubernetesPath\wins.exe" https://github.com/rancher/wins/releases/download/v0.0.4/wins.exe
-
-if ($ContainerRuntime -eq "Docker") {
-    # Create host network to allow kubelet to schedule hostNetwork pods
-    # NOTE: For containerd the 0-containerd-nat.json network config template added by
-    # Install-containerd.ps1 joins pods to the host network.
-    Write-Host "Creating Docker host network"
-    docker network create -d nat host
-} elseif ($ContainerRuntime -eq "containerD") {
-    DownloadFile "c:\k\hns.psm1" https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/hns.psm1
-    Import-Module "c:\k\hns.psm1"
-    # TODO(marosset): check if network already exists before creatation
-    New-HnsNetwork -Type NAT -Name nat
-}
-
-Write-Host "Registering wins service"
-wins.exe srv app run --register
-start-service rancher-wins
 
 mkdir -force C:\var\log\kubelet
 mkdir -force C:\var\lib\kubelet\etc\kubernetes
@@ -103,19 +72,8 @@ if ($CurrentVersion -lt $V1_24_Version) {
 $StartKubeletFileContent = '$FileContent = Get-Content -Path "/var/lib/kubelet/kubeadm-flags.env"
 $global:KubeletArgs = $FileContent.TrimStart(''KUBELET_KUBEADM_ARGS='').Trim(''"'')
 
-$global:containerRuntime = {{CONTAINER_RUNTIME}}
-
-if ($global:containerRuntime -eq "Docker") {
-    $netId = docker network ls -f name=host --format "{{ .ID }}"
-
-    if ($netId.Length -lt 1) {
-    docker network create -d nat host
-    }
-}
-
 $cmd = "' + $cmd_commands + '"
 Invoke-Expression $cmd'
-$StartKubeletFileContent = $StartKubeletFileContent -replace "{{CONTAINER_RUNTIME}}", "`"$ContainerRuntime`""
 Set-Content -Path $global:StartKubeletScript -Value $StartKubeletFileContent
 
 Write-Host "Installing nssm"
@@ -138,11 +96,7 @@ $newPath = "$global:NssmInstallDirectory;" +
 Write-Host "Registering kubelet service"
 nssm install kubelet $global:Powershell $global:PowershellArgs $global:StartKubeletScript
 
-if ($ContainerRuntime -eq "Docker") {
-    nssm set kubelet DependOnService docker
-} elseif ($ContainerRuntime -eq "containerD") {
-    nssm set kubelet DependOnService containerd
-}
+nssm set kubelet DependOnService containerd
 
 New-NetFirewallRule -Name kubelet -DisplayName 'kubelet' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 10250
 


### PR DESCRIPTION
**Reason for PR**:
To update the Windows scripts: InstallContainerd.ps1 and PrepareNode.ps1. 
The location for containerd was changed to the correct one in the script and the script which installs kubeadm, kubelet was changed to install k8s version v1.25.3 and Docker references were removed because they are deprecated!


**Issue Fixed**:
Problems which may appear because containerd folders are not properly set in the script.

**Notes**:
This PR is based on the same changes to the scripts as PR [#239](https://github.com/kubernetes-sigs/sig-windows-tools/pull/239)

