### PR TITLE
Added missing env variables for flannel and kube-proxy hostprocess

### DIFF
--- a/hostprocess/flannel/flanneld/flannel-overlay.yml
+++ b/hostprocess/flannel/flanneld/flannel-overlay.yml
@@ -111,6 +111,10 @@ spec:
         - name: kube-proxy
           mountPath: /flannel-config-file
         env:
+        - name: CNI_BIN_PATH
+          value: C:\\opt\\cni\\bin
+        - name: CNI_CONFIG_PATH
+          value: C:\\etc\\cni\\net.d
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/hostprocess/flannel/kube-proxy/kube-proxy.yml
+++ b/hostprocess/flannel/kube-proxy/kube-proxy.yml
@@ -29,6 +29,8 @@ spec:
         # https://github.com/kubernetes/kubernetes/blob/b0bc8adbc2178e15872f9ef040355c51c45d04bb/pkg/proxy/winkernel/proxier.go#L155-L158
         - name: KUBE_NETWORK
           value: "flannel.4096"
+        - name: CNI_BIN_PATH
+          value: C:\\opt\\cni\\bin
         - name: NODE_NAME
           valueFrom:
             fieldRef:


### PR DESCRIPTION
**Reason for PR**:
Adds the missing env vars mentioned in #264


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #264

**Requirements**

- [ ] Sqaush commits 
- [ ] Documentation
- [ ] Tests

**Notes**:


