### PR TITLE
Fix incompatible cni versions

### DIFF
--- a/hostprocess/flannel/flanneld/flannel-overlay.yml
+++ b/hostprocess/flannel/flanneld/flannel-overlay.yml
@@ -11,7 +11,7 @@ data:
   cni-conf-containerd.json: |
     {
       "name": "flannel.4096",
-      "cniVersion": "0.3.1",
+      "cniVersion": "0.2.0",
       "type": "flannel",
       "capabilities": {
         "portMappings": true,


### PR DESCRIPTION
**Reason for PR**:
Reverts the cni version for flannel hostprocess back to 0.2.0 which was mentioned/recommended by @fabi200123 in https://github.com/kubernetes-sigs/sig-windows-tools/issues/264#issuecomment-1364086501


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #266 

**Requirements**

- [ ] Sqaush commits 
- [ ] Documentation
- [ ] Tests

**Notes**:


