### PR TITLE
update burrito golang build version

### DIFF
--- a/burrito/Dockerfile
+++ b/burrito/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILDER_IMAGE=golang:1.16
+ARG BUILDER_IMAGE=golang:1.19
 ARG RUN_IMAGE=ubuntu:latest
 
 FROM ${BUILDER_IMAGE} as builder


### PR DESCRIPTION
**Reason for PR**:
Updates burrito builder base to golang `1.19` for compatibility with updated golang modules


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Issue #

**Requirements**

- [ ] Sqaush commits 
- [ ] Documentation
- [ ] Tests

**Notes**:


