### PR TITLE
Specify --provenance=false for hpc containers

### DIFF
--- a/hostprocess/calico/build.sh
+++ b/hostprocess/calico/build.sh
@@ -26,19 +26,19 @@ trap 'docker buildx rm img-builder' EXIT
 if [[ -n "$calicoVersion" || "$all" == "1" ]] ; then
     trap 'docker buildx rm img-builder' EXIT
     pushd install
-    docker buildx build --platform windows/amd64 --output=type=registry --pull --build-arg=CALICO_VERSION=$calicoVersion -f Dockerfile.install -t $repository/calico-install:$calicoVersion-hostprocess .
+    docker buildx build --provenance=false --platform windows/amd64 --output=type=registry --pull --build-arg=CALICO_VERSION=$calicoVersion -f Dockerfile.install -t $repository/calico-install:$calicoVersion-hostprocess .
     popd
 fi
 
 if [[ -n "$calicoVersion" || "$all" == "1" ]] ; then
     pushd node
-    docker buildx build --platform windows/amd64 --output=type=registry --pull --build-arg=CALICO_VERSION=$calicoVersion -f Dockerfile.node -t $repository/calico-node:$calicoVersion-hostprocess .
+    docker buildx build --provenance=false --platform windows/amd64 --output=type=registry --pull --build-arg=CALICO_VERSION=$calicoVersion -f Dockerfile.node -t $repository/calico-node:$calicoVersion-hostprocess .
     popd
 fi
 
 if [[ -n "$proxyVersion" || "$all" == "1" ]] ; then
     proxyVersion=${proxyVersion:-"v1.22.4"}
     pushd kube-proxy
-    docker buildx build --platform windows/amd64 --output=type=registry --pull --build-arg=k8sVersion=$proxyVersion -f Dockerfile -t $repository/kube-proxy:$proxyVersion-calico-hostprocess .
+    docker buildx build --provenance=false --platform windows/amd64 --output=type=registry --pull --build-arg=k8sVersion=$proxyVersion -f Dockerfile -t $repository/kube-proxy:$proxyVersion-calico-hostprocess .
     popd
 fi

--- a/hostprocess/flannel/build.sh
+++ b/hostprocess/flannel/build.sh
@@ -26,13 +26,13 @@ if [[ -n "$flannelVersion" || "$all" == "1" ]] ; then
   # set default
   flannelVersion=${flannelVersion:-"v0.13.0"}
   pushd flanneld
-  docker buildx build --platform windows/amd64 --output=type=registry --pull --build-arg=flannelVersion=$flannelVersion -f Dockerfile -t $repository/flannel:$flannelVersion-hostprocess .
+  docker buildx build --provenance=false --platform windows/amd64 --output=type=registry --pull --build-arg=flannelVersion=$flannelVersion -f Dockerfile -t $repository/flannel:$flannelVersion-hostprocess .
   popd
 fi 
 
 if [[ -n "$proxyVersion" || "$all" == "1" ]] ; then
   proxyVersion=${proxyVersion:-"v1.22.4"}
   pushd kube-proxy
-  docker buildx build --platform windows/amd64 --output=type=registry --pull --build-arg=k8sVersion=$proxyVersion -f Dockerfile -t $repository/kube-proxy:$proxyVersion-flannel-hostprocess .
+  docker buildx build --provenance=false --platform windows/amd64 --output=type=registry --pull --build-arg=k8sVersion=$proxyVersion -f Dockerfile -t $repository/kube-proxy:$proxyVersion-flannel-hostprocess .
   popd
 fi


### PR DESCRIPTION
**Reason for PR**:
There is an issue in older patch versions of containerd where host-process-container images built with buildkit v0.10.x will fail on Windows nodes due to how the attestation manifests (which are generated by default) are formed.
setting `--provenance=false` will prevent the attestation manifests from being generated.

More info in https://github.com/containerd/containerd/issues/8070


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Issue #

**Requirements**

- [ ] Sqaush commits 
- [ ] Documentation
- [ ] Tests

**Notes**:


