### PR TITLE
guide: Fixes calico hostprocess image version

### DIFF
--- a/guides/guide-for-adding-windows-node.md
+++ b/guides/guide-for-adding-windows-node.md
@@ -153,7 +153,7 @@ Now you can add Windows-compatible versions of calico and kube-proxy. In order t
 
 ```bash
 curl -L https://raw.githubusercontent.com/kubernetes-sigs/sig-windows-tools/master/hostprocess/calico/kube-proxy/kube-proxy.yml | sed 's/KUBE_PROXY_VERSION/v1.25.3/g' | kubectl apply -f -
-curl -L https://raw.githubusercontent.com/kubernetes-sigs/sig-windows-tools/master/hostprocess/calico/calico.yml | sed 's/CALICO_VERSION/$CALICO_VERSION/g' | kubectl apply -f -
+curl -L https://raw.githubusercontent.com/kubernetes-sigs/sig-windows-tools/master/hostprocess/calico/calico.yml | sed "s/CALICO_VERSION/$CALICO_VERSION/g" | kubectl apply -f -
 kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/sig-windows-tools/master/hostprocess/calico/kube-calico-rbac.yml
 ```
 


### PR DESCRIPTION
**Reason for PR**:
<!-- What does this PR improve or fix? -->

In the guide, the calico.yml file is downloaded and the ``CALICO_VERSION`` is supposed to be replaced through sed. However, variable substitution doesn't work if it's put in apostrophes, which results in pods not working properly.


