### PR TITLE
Support containerd 1.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 .venv
+.vs

--- a/hostprocess/flannel/flanneld/flannel-overlay.yml
+++ b/hostprocess/flannel/flanneld/flannel-overlay.yml
@@ -103,11 +103,11 @@ spec:
         imagePullPolicy: Always
         volumeMounts:
         - name: flannel-cfg
-          mountPath: /etc/kube-flannel/
+          mountPath: /mounts/kube-flannel/
         - name: flannel-windows-cfg
-          mountPath: /etc/kube-flannel-windows/
+          mountPath: /mounts/kube-flannel-windows/
         - name: kubeadm-config
-          mountPath: /etc/kubeadm-config/
+          mountPath: /mounts/kubeadm-config/
         - name: kube-proxy
           mountPath: /flannel-config-file
         env:

--- a/hostprocess/flannel/flanneld/start.ps1
+++ b/hostprocess/flannel/flanneld/start.ps1
@@ -8,15 +8,15 @@ Copy-Item -Path "$env:CONTAINER_SANDBOX_MOUNT_POINT/cni/*" -Destination "$env:CN
 Write-Host "copy flannel config"
 mkdir -force C:\etc\kube-flannel\
 ls C:\etc\kube-flannel\
-ls $env:CONTAINER_SANDBOX_MOUNT_POINT/etc/kube-flannel/
-cp -force $env:CONTAINER_SANDBOX_MOUNT_POINT/etc/kube-flannel/net-conf.json  C:\etc\kube-flannel\net-conf.json
+ls $env:CONTAINER_SANDBOX_MOUNT_POINT/mounts/kube-flannel/
+cp -force $env:CONTAINER_SANDBOX_MOUNT_POINT/mounts/kube-flannel/net-conf.json  C:\etc\kube-flannel\net-conf.json
 
 # configure cni
 # get info
 Write-Host "update cni config"
-$cniJson = get-content $env:CONTAINER_SANDBOX_MOUNT_POINT/etc/kube-flannel-windows/cni-conf-containerd.json | ConvertFrom-Json
-$serviceSubnet = get-content $env:CONTAINER_SANDBOX_MOUNT_POINT/etc/kubeadm-config/ClusterConfiguration | ForEach-Object -Process {if($_.Contains("serviceSubnet:")) {$_.Trim().Split()[1]}}
-$podSubnet = get-content $env:CONTAINER_SANDBOX_MOUNT_POINT/etc/kubeadm-config/ClusterConfiguration | ForEach-Object -Process {if($_.Contains("podSubnet:")) {$_.Trim().Split()[1]}}
+$cniJson = get-content $env:CONTAINER_SANDBOX_MOUNT_POINT/mounts/kube-flannel-windows/cni-conf-containerd.json | ConvertFrom-Json
+$serviceSubnet = get-content $env:CONTAINER_SANDBOX_MOUNT_POINT/mounts/kubeadm-config/ClusterConfiguration | ForEach-Object -Process {if($_.Contains("serviceSubnet:")) {$_.Trim().Split()[1]}}
+$podSubnet = get-content $env:CONTAINER_SANDBOX_MOUNT_POINT/mounts/kubeadm-config/ClusterConfiguration | ForEach-Object -Process {if($_.Contains("podSubnet:")) {$_.Trim().Split()[1]}}
 $na = Get-NetRoute | Where { $_.DestinationPrefix -eq '0.0.0.0/0' } | Select-Object -Property ifIndex
 $managementIP = (Get-NetIPAddress -ifIndex $na[0].ifIndex -AddressFamily IPv4).IPAddress
 

--- a/hostprocess/flannel/kube-proxy/kube-proxy.yml
+++ b/hostprocess/flannel/kube-proxy/kube-proxy.yml
@@ -41,7 +41,7 @@ spec:
             fieldRef:
               fieldPath: status.podIP
         volumeMounts:
-        - mountPath: /var/lib/kube-proxy
+        - mountPath: /mounts/var/lib/kube-proxy
           name: kube-proxy
       nodeSelector:
         kubernetes.io/os: windows

--- a/hostprocess/flannel/kube-proxy/start.ps1
+++ b/hostprocess/flannel/kube-proxy/start.ps1
@@ -52,8 +52,8 @@ function GetSourceVip($NetworkName)
 #   https://github.com/kubernetes/kubernetes/blob/9f0f14952c51e7a5622eac05c541ba20b5821627/cmd/kubeadm/app/phases/addons/proxy/manifests.go
 Write-Host "Write files so the kubeconfig points to correct locations"
 mkdir -force /var/lib/kube-proxy/
-((Get-Content -path $env:CONTAINER_SANDBOX_MOUNT_POINT/var/lib/kube-proxy/kubeconfig.conf -Raw) -replace '/var',"$($env:CONTAINER_SANDBOX_MOUNT_POINT)/var") | Set-Content -Path $env:CONTAINER_SANDBOX_MOUNT_POINT/var/lib/kube-proxy/kubeconfig.conf
-cp $env:CONTAINER_SANDBOX_MOUNT_POINT/var/lib/kube-proxy/kubeconfig.conf /var/lib/kube-proxy/kubeconfig.conf
+((Get-Content -path $env:CONTAINER_SANDBOX_MOUNT_POINT/mounts/var/lib/kube-proxy/kubeconfig.conf -Raw) -replace '/var',"$($env:CONTAINER_SANDBOX_MOUNT_POINT)/var") | Set-Content -Path $env:CONTAINER_SANDBOX_MOUNT_POINT/mounts/var/lib/kube-proxy/kubeconfig.conf
+cp $env:CONTAINER_SANDBOX_MOUNT_POINT/mounts/var/lib/kube-proxy/kubeconfig.conf /var/lib/kube-proxy/kubeconfig.conf
 
 Write-Host "Finding sourcevip"
 $vip = GetSourceVip -NetworkName $env:KUBE_NETWORK
@@ -64,7 +64,7 @@ $arguements = "--v=6",
         "--feature-gates=WinOverlay=true",
         "--proxy-mode=kernelspace",
         "--source-vip=$vip",
-        "--kubeconfig=$env:CONTAINER_SANDBOX_MOUNT_POINT/var/lib/kube-proxy/kubeconfig.conf"
+        "--kubeconfig=$env:CONTAINER_SANDBOX_MOUNT_POINT/mounts/var/lib/kube-proxy/kubeconfig.conf"
 
 $exe = "$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/kube-proxy.exe " + ($arguements -join " ")
 


### PR DESCRIPTION
**Reason for PR**:
<!-- What does this PR improve or fix? -->
The `kube-flannel` and `kube-proxy` pods were failing/crashing with containerd 1.7.0. This was because of the usage of `bind volume` instead of `symlink volume` (see [here](https://github.com/kubernetes/enhancements/tree/master/keps/sig-windows/1981-windows-privileged-container-support#compatibility)).
This problem was first mentioned in #289 and here: https://github.com/kubernetes-sigs/sig-windows-tools/issues/277#issuecomment-1512099019

For details check this comment: https://github.com/kubernetes-sigs/sig-windows-tools/issues/277#issuecomment-1518117147

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #289

**Requirements**

- [ ] Sqaush commits 
- [ ] Documentation
- [ ] Tests

**Notes**:
I decided to move the mounts to `/mounts/...` instead of directly mounting them to the root because of two reasons:
- This didn't worked for kube-proxy since the Dockerfile already writes into/uses `/kube-proxy`
- `/mounts/...` maybe better communicates that these are actual mounts which was really hard for me to understand due to the behavior of hostprocess containers.


