### PR TITLE
Correct vxlan settings in guide

### DIFF
--- a/guides/guide-for-adding-windows-node.md
+++ b/guides/guide-for-adding-windows-node.md
@@ -94,6 +94,7 @@ curl -L https://raw.githubusercontent.com/kubernetes-sigs/sig-windows-tools/mast
 > `kubeadm version`
 
 5. Apply kube-flannel-rbac.yml from sig-windows-tools/kubeadm/flannel
+
 Modify the `net-conf.json` section of the flannel manifest in order to set the VNI to 4096 and the Port to 4789 here as well.
 Next you will need to apply the configuration that allows flannel to spawn pods and keep them running:
 

--- a/guides/guide-for-adding-windows-node.md
+++ b/guides/guide-for-adding-windows-node.md
@@ -94,10 +94,11 @@ curl -L https://raw.githubusercontent.com/kubernetes-sigs/sig-windows-tools/mast
 > `kubeadm version`
 
 5. Apply kube-flannel-rbac.yml from sig-windows-tools/kubeadm/flannel
+Modify the `net-conf.json` section of the flannel manifest in order to set the VNI to 4096 and the Port to 4789 here as well.
 Next you will need to apply the configuration that allows flannel to spawn pods and keep them running:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/sig-windows-tools/master/hostprocess/flannel/flanneld/kube-flannel-rbac.yml
+curl -L https://raw.githubusercontent.com/kubernetes-sigs/sig-windows-tools/master/hostprocess/flannel/flanneld/kube-flannel-rbac.yml | sed s'/"Type": "vxlan"/"Type": "vxlan", "VNI": 4096, "Port": 4789/' | kubectl apply -f -
 ```
 
 


### PR DESCRIPTION
Correction in section 5 - Apply kube-flannel-rbac.yml from sig-windows-tools/kubeadm/flannel

The file kube-flannel-rbac.yml contains also a net-conf.json section which must also
contain the VNI (4096) and the Port (4789). Added an sed-command to apply those
changes during installation.