### PR TITLE
Correct vxlan in guide

### DIFF
--- a/guides/guide-for-adding-windows-node.md
+++ b/guides/guide-for-adding-windows-node.md
@@ -94,12 +94,10 @@ curl -L https://raw.githubusercontent.com/kubernetes-sigs/sig-windows-tools/mast
 > `kubeadm version`
 
 5. Apply kube-flannel-rbac.yml from sig-windows-tools/kubeadm/flannel
-
-Modify the `net-conf.json` section of the flannel manifest in order to set the VNI to 4096 and the Port to 4789 here as well.
 Next you will need to apply the configuration that allows flannel to spawn pods and keep them running:
 
 ```bash
-curl -L https://raw.githubusercontent.com/kubernetes-sigs/sig-windows-tools/master/hostprocess/flannel/flanneld/kube-flannel-rbac.yml | sed s'/"Type": "vxlan"/"Type": "vxlan", "VNI": 4096, "Port": 4789/' | kubectl apply -f -
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/sig-windows-tools/master/hostprocess/flannel/flanneld/kube-flannel-rbac.yml
 ```
 
 

--- a/guides/guide-for-adding-windows-node.md
+++ b/guides/guide-for-adding-windows-node.md
@@ -94,6 +94,7 @@ curl -L https://raw.githubusercontent.com/kubernetes-sigs/sig-windows-tools/mast
 > `kubeadm version`
 
 5. Apply kube-flannel-rbac.yml from sig-windows-tools/kubeadm/flannel
+
 Modify the `net-conf.json` section of the flannel manifest in order to set the VNI to 4096 and the Port to 4789 here as well.
 Next you will need to apply the configuration that allows flannel to spawn pods and keep them running:
 

--- a/guides/guide-for-adding-windows-node.md
+++ b/guides/guide-for-adding-windows-node.md
@@ -94,10 +94,11 @@ curl -L https://raw.githubusercontent.com/kubernetes-sigs/sig-windows-tools/mast
 > `kubeadm version`
 
 5. Apply kube-flannel-rbac.yml from sig-windows-tools/kubeadm/flannel
+Modify the `net-conf.json` section of the flannel manifest in order to set the VNI to 4096 and the Port to 4789 here as well.
 Next you will need to apply the configuration that allows flannel to spawn pods and keep them running:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/sig-windows-tools/master/hostprocess/flannel/flanneld/kube-flannel-rbac.yml
+curl -L https://raw.githubusercontent.com/kubernetes-sigs/sig-windows-tools/master/hostprocess/flannel/flanneld/kube-flannel-rbac.yml | sed s'/"Type": "vxlan"/"Type": "vxlan", "VNI": 4096, "Port": 4789/' | kubectl apply -f -
 ```
 
 

--- a/hostprocess/flannel/flanneld/kube-flannel-rbac.yml
+++ b/hostprocess/flannel/flanneld/kube-flannel-rbac.yml
@@ -75,6 +75,8 @@ data:
     {
       "Network": "10.244.0.0/16",
       "Backend": {
-        "Type": "vxlan"
+        "Type": "vxlan",
+        "VNI" : 4096,
+        "Port": 4789
       }
     }


### PR DESCRIPTION
The installation guide describes in chapter 5 how to apply kube-flannel-rbac.yml to the windows node. The corresponding yml file does not contain the correct vxlan configuration using VNI: 4096 and Port: 4789.
The guide description was changed to inject the correct vxlan settings during the kubectl apply command.