### PR TITLE
add vni and port to cni-conf.json in kube-flannel-rbac.yml

### DIFF
--- a/hostprocess/flannel/flanneld/kube-flannel-rbac.yml
+++ b/hostprocess/flannel/flanneld/kube-flannel-rbac.yml
@@ -75,6 +75,8 @@ data:
     {
       "Network": "10.244.0.0/16",
       "Backend": {
-        "Type": "vxlan"
+        "Type": "vxlan",
+        "VNI" : 4096,
+        "Port": 4789
       }
     }


### PR DESCRIPTION
The cni-conf.json configmap in kube-flannel-rbac.yml 
does not contain the VNI and Port required for windows vxlan communication. 
This is added.