### PR TITLE
Add option to skip CPU check for Hypervisor support

### DIFF
--- a/guides/guide-for-adding-windows-node.md
+++ b/guides/guide-for-adding-windows-node.md
@@ -159,21 +159,30 @@ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/sig-windows-t
 
 > **Note:** All code snippets in Windows sections are to be run in a PowerShell environment with elevated permissions (Administrator) on the Windows worker node.
 
-1. Install ContainerD, wins, kubelet, and kubeadm.
+1. Install ContainerD.
 
 ```PowerShell
 # Install ContainerD
 curl.exe -LO https://raw.githubusercontent.com/kubernetes-sigs/sig-windows-tools/master/hostprocess/Install-Containerd.ps1
-.\Install-Containerd.ps1
+.\Install-Containerd.ps1 -ContainerDVersion 1.7.1 
+```
 
+> **Note** Adjust the parameters for `Install-Containerd.ps1` as you need them.
+
+> **Note** Set `skipHypervisorSupportCheck` if your machine does not support Hyper-V. You way wont be able to host Hyper-V isolated containers.  
+Example: `.\Install-Containerd.ps1 -ContainerDVersion 1.7.1 -netAdapterName Ethernet -skipHypervisorSupportCheck`
+
+2. Install kubelet and kubeadm.
+
+```PowerShell
 # Install kubelet and kubeadm
 curl.exe -LO https://raw.githubusercontent.com/kubernetes-sigs/sig-windows-tools/master/hostprocess/PrepareNode.ps1
 .\PrepareNode.ps1 -KubernetesVersion v1.25.3
 ```
 
-> **Note** If you want to install another version of kubernetes, modify v1.24.3 with the version you want to install
+> **Note** If you want to install another version of kubernetes, modify v1.25.3 with the version you want to install
 
-2. Run `kubeadm` to join the node
+3. Run `kubeadm` to join the node
 
 > **Note** Before joining the node, copy the file from /run/flannel/subnet.env to your windows machine to C:\run\flannel\subnet.env
 > You will need to create the folders for it
@@ -182,7 +191,7 @@ Use the command that was given to you when you ran `kubeadm init` on a control p
 
 > **Note:** Do not forget to add `--cri-socket "npipe:////./pipe/containerd-containerd" --v=5` at the end of the join command, if you use ContainerD
 
-3. Install kubectl for windows (optional)
+4. Install kubectl for windows (optional)
 
 For more information about it : https://kubernetes.io/docs/tasks/tools/install-kubectl-windows/
 


### PR DESCRIPTION
**Reason for PR**:
Adds an option to install containerD on a machine which doesn't support Hyper-V.
If used the same workaround as described here is used: https://github.com/kubernetes-sigs/image-builder/blob/3c9c5642ac78be02ff631a19fef6fc3dab4c1a90/images/capi/ansible/windows/roles/systemprep/tasks/main.yml#L157-L176

**Issue Fixed**:
Fixes #296

**Requirements**

- [ ] Sqaush commits 
- [ ] Documentation
- [ ] Tests

**Notes**:
I also changed the default value for `ContainerDVersion` from `1.6.8` to `1.7.1`. I can revert that if not feasible.