### PR TITLE
Remove conflicting ClusterRole

### DIFF
--- a/hostprocess/flannel/flanneld/kube-flannel-rbac.yml
+++ b/hostprocess/flannel/flanneld/kube-flannel-rbac.yml
@@ -5,35 +5,10 @@ metadata:
   name: flannel
   namespace: kube-system
 ---
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: flannel
-rules:
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-    verbs:
-      - get
-  - apiGroups:
-      - ""
-    resources:
-      - nodes
-    verbs:
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - nodes/status
-    verbs:
-      - patch
----
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: flannel
+  name: flannel-windows
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
**Reason for PR**:
As described in #277 the current rbac rules overwrite some of the linux part of kube-flannel. This PR generally solves it.
But note, also as described in #277 this is more likely a workaround as a real solution. A better solution would be to align with kube-flannel for linux and move to the kube-flannel namespace. This enables us to completely get rid of the custom rbac rules and use the one of kube-flannel for linux. BUT we possibly need a bigger change in flannel for this to work (see https://github.com/kubernetes-sigs/sig-windows-tools/issues/277#issuecomment-1518886777 and https://github.com/flannel-io/flannel/issues/1772). This may or may not still take some time.

Once this PR is merged I'm going to open a draft PR which prepares everything for the real change. We then just need to update the flannel version and everything should work then.

**Issue Fixed**:
Fixes #277

**Requirements**

- [ ] Sqaush commits 
- [ ] Documentation
- [ ] Tests