### PR TITLE
Fixing test-kube-proxy-images GH action by performing a docker login

### DIFF
--- a/.github/workflows/test-kube-proxy-images.yaml
+++ b/.github/workflows/test-kube-proxy-images.yaml
@@ -12,6 +12,11 @@ jobs:
     runs-on: windows-latest
 
     steps:
+    - name: dockerhub login
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_SECRET }}
     - uses: actions/checkout@v2
     - name: Test kube-proxy images
       run: powershell.exe ./hack/test-kube-proxy-images.ps1


### PR DESCRIPTION
**Reason for PR**:
We need to authenticate to get manifest information from sigwindowstools docker hub repositories

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Issue #

**Requirements**

- [ ] Sqaush commits 
- [ ] Documentation
- [ ] Tests

**Notes**:
The github action job is passing in my fork/branch with these changes - https://github.com/marosset/sig-windows-tools/actions/runs/5006111094

/assign @jsturtevant 