### PR TITLE
Adding GH action workflows for building flannel and flannel kube-proxy images

### DIFF
--- a/.github/workflows/build-flannel-images.yml
+++ b/.github/workflows/build-flannel-images.yml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Build Flannel images
+
+on:
+  workflow_dispatch:
+    inputs:
+      flannel_version:
+        description: 'Version of flannel to build image for (ex: v0.21.5)'
+        required: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build and push images
+      run: |
+        echo "${{ secrets.DOCKER_SECRET }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+        cd ./hostprocess/flannel && ./build.sh -f ${{ github.event.inputs.flannel_version }}

--- a/.github/workflows/build-kube-proxy-images.yml
+++ b/.github/workflows/build-kube-proxy-images.yml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
-name: Build Calico Kube-Proxy images
+name: Build Kube-Proxy images
 
 on:
   workflow_dispatch:
@@ -16,4 +16,8 @@ jobs:
     - name: Build and push images
       run: |
         echo "${{ secrets.DOCKER_SECRET }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-        cd ./hostprocess/calico && ./build.sh -p ${{ github.event.inputs.proxy_version }}
+        pushd ./hostprocess/calico 
+        ./build.sh -p ${{ github.event.inputs.proxy_version }}
+        popd
+        pushd ./hostprocess/flannel
+        ./build.sh -p ${{ github.event.inputs.proxy_version}}


### PR DESCRIPTION

**Reason for PR**:
<!-- What does this PR improve or fix? -->

- Adds a GH action for building new versions of the flannel image
- Updates the GH action used to build kube-proxy images to also build them for flannel CNI (instead of just calico)

Adding GH 
**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Partially fixies #317 

**Requirements**

- [ ] Sqaush commits 
- [ ] Documentation
- [ ] Tests

**Notes**:

/assign @Mik4sa 
