### PR TITLE
Improvements to InstallContainerd.ps1 and PrepareNode.ps1

### DIFF
--- a/guides/calico.md
+++ b/guides/calico.md
@@ -64,7 +64,7 @@ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/sig-windows-t
 >  **Note** If you changed the `$CNIBinPath` or `$CNIConfigPath` optional parameters when running `Install-Containerd.ps1`,
 >  you will need to use those paths on `calico.yml`. Pipe it through
 >  `| sed 's/C:\\\\opt\\\\cni\\\\bin/<your cni bin path>/g' | sed 's/C:\\\\etc\\\\cni\\\\net.d/<your cni config path>/g' | sed 's/opt\/cni\/bin/<your cni bin path>/g' | sed 's/etc\/cni\/net.d/<your cni config path>/g'`
->  before feeding it to `kubectl apply -f -`. Mind the forward/backward slash formats, manually editing the `calico.yml` file might be easier.
+>  before feeding it to `kubectl apply -f -`. Mind the forward slash/backslash formats, manually editing the `calico.yml` file might be easier.
 
 The `$CALICO_VERSION` version in the above code section refers to the image of <a href="https://hub.docker.com/r/sigwindowstools/calico-node/tags" target="_blank">sigwindowstools/calico-node</a>, which may trail behind the versions released by Calico as these images are built and published on a best effort.
 

--- a/guides/calico.md
+++ b/guides/calico.md
@@ -24,7 +24,7 @@ The version of Calico will be set in the variable CALICO_VERSION (if another ver
 export CALICO_VERSION="v3.24.5"
 ```
 
-Create the tigera-operator.yaml and the custom-resources.yaml for Calico: 
+Create the tigera-operator.yaml and the custom-resources.yaml for Calico:
 ```bash
 kubectl create -f https://raw.githubusercontent.com/projectcalico/calico/$CALICO_VERSION/manifests/tigera-operator.yaml
 curl https://raw.githubusercontent.com/projectcalico/calico/$CALICO_VERSION/manifests/custom-resources.yaml -O
@@ -60,6 +60,11 @@ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/sig-windows-t
 
 >  **Note** To find your version of kubernetes run the following command:
 > `kubeadm version`
+
+>  **Note** If you changed the `$CNIBinPath` or `$CNIConfigPath` optional parameters when running `Install-Containerd.ps1`,
+>  you will need to use those paths on `calico.yml`. Pipe it through
+>  `| sed 's/C:\\\\opt\\\\cni\\\\bin/<your cni bin path>/g' | sed 's/C:\\\\etc\\\\cni\\\\net.d/<your cni config path>/g' | sed 's/opt\/cni\/bin/<your cni bin path>/g' | sed 's/etc\/cni\/net.d/<your cni config path>/g'`
+>  before feeding it to `kubectl apply -f -`. Mind the forward/backward slash formats, manually editing the `calico.yml` file might be easier.
 
 The `$CALICO_VERSION` version in the above code section refers to the image of <a href="https://hub.docker.com/r/sigwindowstools/calico-node/tags" target="_blank">sigwindowstools/calico-node</a>, which may trail behind the versions released by Calico as these images are built and published on a best effort.
 

--- a/guides/calico.md
+++ b/guides/calico.md
@@ -4,7 +4,7 @@ This should be followed after adding your [Windows node to the cluster with kube
 
 ## Configuring Calico with HostProcess containers
 
->  **Note:** All code snippets in Linux sections are to be run in a Linux environment on the Linux worker node.
+>  **Note** All code snippets in Linux sections are to be run in a Linux environment on the Linux worker node.
 
 ### Prepare Control Plane for Calico
 
@@ -32,7 +32,7 @@ curl https://raw.githubusercontent.com/projectcalico/calico/$CALICO_VERSION/mani
 # After the file has the correct CIDR, run this command:
 kubectl create -f custom-resources.yaml
 ```
->  **Note:** Before creating this manifest, read its contents and make sure its settings are correct for your environment. For example, you may need to change the default IP pool CIDR to match your pod network CIDR.
+>  **Note** Before creating this manifest, read its contents and make sure its settings are correct for your environment. For example, you may need to change the default IP pool CIDR to match your pod network CIDR.
 
 Remove the taints on the master so that you can schedule pods on it.
 
@@ -69,7 +69,7 @@ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/sig-windows-t
 The `$CALICO_VERSION` version in the above code section refers to the image of <a href="https://hub.docker.com/r/sigwindowstools/calico-node/tags" target="_blank">sigwindowstools/calico-node</a>, which may trail behind the versions released by Calico as these images are built and published on a best effort.
 
 ## Verifying your installation for Calico
->  **Note:** Remember to check if you have the calico cni installed on your Windows node ("C:\Program Files\containerd\cni\"). If you do not have it, follow this tutorial to install it: https://projectcalico.docs.tigera.io/getting-started/windows-calico/kubernetes/standard#install-calico-and-kubernetes-on-windows-nodes
+>  **Note** Remember to check if you have the calico cni installed on your Windows node ("C:\Program Files\containerd\cni\"). If you do not have it, follow this tutorial to install it: https://projectcalico.docs.tigera.io/getting-started/windows-calico/kubernetes/standard#install-calico-and-kubernetes-on-windows-nodes
 If you have trouble with modifying config.ps1, use this https://github.com/kubernetes-sigs/sig-windows-dev-tools/blob/master/forked/config.ps1
 
 You should now be able to view the Windows node in your cluster by running:

--- a/guides/flannel.md
+++ b/guides/flannel.md
@@ -77,6 +77,15 @@ curl -L https://raw.githubusercontent.com/kubernetes-sigs/sig-windows-tools/mast
 > To find your version of kubernetes run the following command:
 > `kubeadm version`
 
+>  **Note** If you changed the`$CNIBinPath` or `$CNIConfigPath` optional parameters when running `Install-Containerd.ps1`,
+>  you will need to use those paths on `flannel-overlay.yml`. Pipe it through
+>  `| sed 's/C:\\\\opt\\\\cni\\\\bin/<your cni bin path>/g' | sed 's/C:\\\\etc\\\\cni\\\\net.d/<your cni config path>/g'`
+>  before feeding it to `kubectl apply -f -`.
+
+>  **Note** If you changed the`$CNIBinPath` optional parameter when running `Install-Containerd.ps1`, you will need to
+>  use that path on `kube-proxy.yml`. Pipe it through `| sed 's/C:\\\\opt\\\\cni\\\\bin/<your cni bin path>/g'` before
+>  feeding it to `kubectl apply -f -`.
+
 2. Apply kube-flannel-rbac.yml from sig-windows-tools/kubeadm/flannel
 Next you will need to apply the configuration that allows flannel to spawn pods and keep them running:
 

--- a/guides/flannel.md
+++ b/guides/flannel.md
@@ -36,9 +36,9 @@ net-conf.json: |
     }
 ```
 
-> **Note:** The VNI must be set to 4096 and port 4789 for Flannel on Linux to interoperate with Flannel on Windows. See the [VXLAN documentation](https://github.com/flannel-io/flannel/blob/master/Documentation/backends.md#vxlan). for an explanation of these fields.
+> **Note** The VNI must be set to 4096 and port 4789 for Flannel on Linux to interoperate with Flannel on Windows. See the [VXLAN documentation](https://github.com/flannel-io/flannel/blob/master/Documentation/backends.md#vxlan). for an explanation of these fields.
 
-> **Note:** To use L2Bridge/Host-gateway mode instead change the value of `Type` to `"host-gw"` and omit `VNI` and `Port`.
+> **Note** To use L2Bridge/Host-gateway mode instead change the value of `Type` to `"host-gw"` and omit `VNI` and `Port`.
 
 3. Apply the Flannel manifest and validate
 

--- a/guides/guide-for-adding-windows-node.md
+++ b/guides/guide-for-adding-windows-node.md
@@ -19,7 +19,7 @@ Your Kubernetes server must be at or later than version 1.23. To check the versi
 
 ### Joining a Windows worker node
 
-> **Note:** All code snippets in Windows sections are to be run in a PowerShell environment with elevated permissions (Administrator) on the Windows worker node.
+> **Note** All code snippets in Windows sections are to be run in a PowerShell environment with elevated permissions (Administrator) on the Windows worker node.
 
 1. Install ContainerD.
 
@@ -51,7 +51,7 @@ curl.exe -LO https://raw.githubusercontent.com/kubernetes-sigs/sig-windows-tools
 
 Use the command that was given to you when you ran `kubeadm init` on a control plane host. If you no longer have this command, or the token has expired, you can run `kubeadm token create --print-join-command` (on a control plane host) to generate a new token and join command.
 
-> **Note:** Do not forget to add `--cri-socket "npipe:////./pipe/containerd-containerd" --v=5` at the end of the join command, if you use ContainerD
+> **Note** Do not forget to add `--cri-socket "npipe:////./pipe/containerd-containerd" --v=5` at the end of the join command, if you use ContainerD
 
 4. Install kubectl for windows (optional)
 

--- a/guides/guide-for-adding-windows-node.md
+++ b/guides/guide-for-adding-windows-node.md
@@ -26,13 +26,16 @@ Your Kubernetes server must be at or later than version 1.23. To check the versi
 ```PowerShell
 # Install ContainerD
 curl.exe -LO https://raw.githubusercontent.com/kubernetes-sigs/sig-windows-tools/master/hostprocess/Install-Containerd.ps1
-.\Install-Containerd.ps1 -ContainerDVersion 1.7.1 
+.\Install-Containerd.ps1 -ContainerDVersion 1.7.1
 ```
 
 > **Note** Adjust the parameters for `Install-Containerd.ps1` as you need them.
 
-> **Note** Set `skipHypervisorSupportCheck` if your machine does not support Hyper-V. You way wont be able to host Hyper-V isolated containers.  
-Example: `.\Install-Containerd.ps1 -ContainerDVersion 1.7.1 -netAdapterName Ethernet -skipHypervisorSupportCheck`
+> **Note** Set `skipHypervisorSupportCheck` if your machine does not support Hyper-V. You way wont be able to host Hyper-V isolated containers.
+> Example: `.\Install-Containerd.ps1 -ContainerDVersion 1.7.1 -netAdapterName Ethernet -skipHypervisorSupportCheck`
+
+> **Note** If you change the `Install-Containerd.ps1` optional parameters `$CNIBinPath` and/or `$CNIConfigPath`, you will need to change the calico
+> or flannel configuration accordingly. See the specific guides for more details.
 
 2. Install kubelet and kubeadm.
 

--- a/hostprocess/Install-Containerd.ps1
+++ b/hostprocess/Install-Containerd.ps1
@@ -38,7 +38,7 @@ Param(
     [parameter(HelpMessage = "Skip the CPU check for Hypervisor support. Note that you will not be able to host Hyper-V isolated containers")]
     [switch] $skipHypervisorSupportCheck
     [parameter(HelpMessage = "Path to configure ContainerD to look for CNI binaries")]
-    [string] $CNIBinPath = "c:/opt/cni/bin"
+    [string] $CNIBinPath = "c:/opt/cni/bin",
     [parameter(HelpMessage = "Path to configure ContainerD to look for CNI config files")]
     [string] $CNIConfigPath = "c:/etc/cni/net.d",
 )

--- a/hostprocess/Install-Containerd.ps1
+++ b/hostprocess/Install-Containerd.ps1
@@ -20,10 +20,10 @@ Skip the CPU check for Hypervisor support. You way wont be able to host Hyper-V 
 Check https://github.com/kubernetes-sigs/sig-windows-tools/issues/296#issuecomment-1511695392 for more information.
 
 .PARAMETER CNIBinPath
-Path to configure ContainerD to look for CNI binaries.
+Path to configure ContainerD to look for CNI binaries. Optional, defaults to "c:/opt/cni/bin".
 
 .PARAMETER CNIConfigPath
-Path to configure ContainerD to look for CNI config files.
+Path to configure ContainerD to look for CNI config files. Optional, defaults to "c:/etc/cni/net.d".
 
 .EXAMPLE
 PS> .\Install-Containerd.ps1 -ContainerDVersion 1.7.1 -netAdapterName Ethernet -skipHypervisorSupportCheck -CNIBinPath "c:/opt/cni/bin" -CNIConfigPath "c:/etc/cni/net.d"

--- a/hostprocess/Install-Containerd.ps1
+++ b/hostprocess/Install-Containerd.ps1
@@ -36,7 +36,7 @@ Param(
     [parameter(HelpMessage = "Name of network adapter to use when configuring basic nat network")]
     [string] $netAdapterName = "Ethernet",
     [parameter(HelpMessage = "Skip the CPU check for Hypervisor support. Note that you will not be able to host Hyper-V isolated containers")]
-    [switch] $skipHypervisorSupportCheck
+    [switch] $skipHypervisorSupportCheck,
     [parameter(HelpMessage = "Path to configure ContainerD to look for CNI binaries")]
     [string] $CNIBinPath = "c:/opt/cni/bin",
     [parameter(HelpMessage = "Path to configure ContainerD to look for CNI config files")]

--- a/hostprocess/Install-Containerd.ps1
+++ b/hostprocess/Install-Containerd.ps1
@@ -40,7 +40,7 @@ Param(
     [parameter(HelpMessage = "Path to configure ContainerD to look for CNI binaries")]
     [string] $CNIBinPath = "c:/opt/cni/bin",
     [parameter(HelpMessage = "Path to configure ContainerD to look for CNI config files")]
-    [string] $CNIConfigPath = "c:/etc/cni/net.d",
+    [string] $CNIConfigPath = "c:/etc/cni/net.d"
 )
 
 $ErrorActionPreference = 'Stop'

--- a/hostprocess/calico/calico.yml
+++ b/hostprocess/calico/calico.yml
@@ -160,6 +160,11 @@ spec:
               value: "false"
             - name: K8S_SERVICE_CIDR
               value: "10.96.0.0/12"
+            # CNI bin and config paths used by install.ps1
+            - name: CNI_BIN_DIR
+              value: "c:\\opt\\cni\\bin"
+            - name: CNI_CONF_DIR
+              value: "c:\\etc\\cni\\net.d"
           volumeMounts:
             - mountPath: /host/opt/cni/bin
               name: cni-bin-dir

--- a/hostprocess/calico/install/calico-install.ps1
+++ b/hostprocess/calico/install/calico-install.ps1
@@ -1,16 +1,16 @@
-$env:CNI_BIN_DIR="c:/opt/cni/bin"
-$env:CNI_CONF_DIR="c:/etc/cni/net.d"
+# The CNI_BIN_DIR and CNI_CONF_DIR environment variables must be defined in the install-cni initContainer of the
+# calico-node-windows daemonset. Otherwise, these values are not configurable.
 
 Write-Host "Starting install. Cleaning up any previous files"
 Remove-Item -Path $env:CNI_BIN_DIR/* -Recurse
-Remove-Item -Path $env:CNI_BIN_DIR/* -Recurse
+Remove-Item -Path $env:CNI_CONF_DIR/* -Recurse
 
 Write-Host "Writing calico kubeconfig to $env:CNI_CONF_DIR"
 $token = Get-Content -Path "$env:CONTAINER_SANDBOX_MOUNT_POINT/var/run/secrets/kubernetes.io/serviceaccount/token"
 $ca = Get-Content -Raw -Path "$env:CONTAINER_SANDBOX_MOUNT_POINT/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 $caBase64 = [System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($ca))
 
-# TODO figure out how the kubernetes service endpoint works in Linux.  
+# TODO figure out how the kubernetes service endpoint works in Linux.
 # For windows since kubeproxy hasn't started the endpoints are not configured on the SVC
 # look it up via kubeadm configuration
 $cpEndpoint = get-content $env:CONTAINER_SANDBOX_MOUNT_POINT/etc/kubeadm-config/ClusterConfiguration | ForEach-Object -Process {if($_.Contains("controlPlaneEndpoint:")) {$_.Trim().Split()[1]}}


### PR DESCRIPTION
(from the Calico forks on https://docs.tigera.io/calico/3.26/scripts/PrepareNode.ps1 and https://docs.tigera.io/calico/3.26/scripts/Install-Containerd.ps1)

InstallContainerd.ps1:
- Add $CNIBinPath and $CNIConfigPath optional flags (defaulting to the currently hardcoded "c:/opt/cni/bin" and "c:/etc/cni/net.d")
- Make sure both paths exist with 'mkdir -force'

PrepareNode.ps1:
- Add setup for log rotation for kubelet on nssm

**Reason for PR**:
<!-- What does this PR improve or fix? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Issue #

**Requirements**

- [ ] Sqaush commits 
- [ ] Documentation
- [ ] Tests

**Notes**:


