### PR TITLE
fixing csi-proxy manifest-list builds

### DIFF
--- a/hostprocess/csi-proxy/Dockerfile.windows
+++ b/hostprocess/csi-proxy/Dockerfile.windows
@@ -2,7 +2,7 @@ ARG REGISTRY=mcr.microsoft.com/windows
 ARG WINDOWS_BASE_IMAGE=nanoserver
 ARG WINDOWS_VERSION=1809
 
-FROM --platform=linux/amd64 golang:1.16 as builder
+FROM --platform=linux/amd64 golang:1.20 as builder
 ARG CSI_PROXY_VERSION=v1.1.2
 RUN git clone https://github.com/kubernetes-csi/csi-proxy.git /go/csi-proxy &&\
     cd /go/csi-proxy &&\

--- a/hostprocess/csi-proxy/build.sh
+++ b/hostprocess/csi-proxy/build.sh
@@ -48,7 +48,7 @@ manifest_entries=""
 
 # Build container images with buildx
 for win_ver in "${win_vers[@]}"; do
-  docker buildx build --platform windows/amd64 --output=$output -f Dockerfile.windows --build-arg=WINDOWS_VERSION=$win_ver -t ${repository}/csi-proxy:${version}-$win_ver .
+  docker buildx build --provenance=false --sbom=false --platform windows/amd64 --output=$output -f Dockerfile.windows --build-arg=WINDOWS_VERSION=$win_ver -t ${repository}/csi-proxy:${version}-$win_ver .
 
   manifest_entries="$manifest_entries ${repository}/csi-proxy:${version}-$win_ver"
 done


### PR DESCRIPTION
**Reason for PR**:
<!-- What does this PR improve or fix? -->
- Bumping golang version from `v1.16` to `v1.20`
- Fixing issue with building the image manifest (buildkit 10.x creates manifest-lists with SBOM info unless you specify --sbom=false and this breaks the build script)


I built and pushed https://hub.docker.com/layers/mrosse3/csi-proxy/v1.1.2/images/sha256-94f8de9302bb607a9d1955870aa9b180333bb8e767f31341181625b0a8386b51?context=repo with these changes

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Issue #

**Requirements**

- [x] Sqaush commits 
- [ ] Documentation
- [ ] Tests

**Notes**:

/sig windows
/assign @jsturtevant @davhdavh 
