### PR TITLE
Fix kubelet log spam

### DIFF
--- a/hostprocess/PrepareNode.ps1
+++ b/hostprocess/PrepareNode.ps1
@@ -64,6 +64,7 @@ $kubeletLogPath = "C:\var\log\kubelet"
 mkdir -force $kubeletLogPath
 mkdir -force C:\var\lib\kubelet\etc\kubernetes
 mkdir -force C:\etc\kubernetes\pki
+mkdir -Force c:\etc\kubernetes\manifests
 New-Item -path C:\var\lib\kubelet\etc\kubernetes\pki -type SymbolicLink -value C:\etc\kubernetes\pki\
 
 # dockershim related flags (--image-pull-progress-deadline=20m and --network-plugin=cni)  are removed in k8s v1.24


### PR DESCRIPTION
**Reason for PR**:
<!-- What does this PR improve or fix? -->
Create `c:/etc/kubernetes/manifests` path in PrepareNode.ps1 to fix kubelet log spam about it not existing.

See https://github.com/kubernetes-sigs/sig-windows-tools/issues/334 for more details.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes https://github.com/kubernetes-sigs/sig-windows-tools/issues/334

**Requirements**

- [ ] Squash commits 
- [ ] Documentation
- [ ] Tests

**Notes**:


