### PR TITLE
Fix NODENAME env var in calico kube-proxy.yml

### DIFF
--- a/hostprocess/calico/kube-proxy/kube-proxy.yml
+++ b/hostprocess/calico/kube-proxy/kube-proxy.yml
@@ -27,7 +27,7 @@ spec:
         name: kube-proxy
         imagePullPolicy: Always
         env:
-        - name: NODE_NAME
+        - name: NODENAME
           valueFrom:
             fieldRef:
               apiVersion: v1


### PR DESCRIPTION
**Reason for PR**:
<!-- What does this PR improve or fix? -->
In the calico kube-proxy.yml file, the daemonset was setting the NODE_NAME env var to spec.nodeName, but in the kube-proxy start.ps1 script, it was looking for a var called NODENAME:
https://github.com/kubernetes-sigs/sig-windows-tools/blob/3ed28295f8694dffd03e144af4423137b2b8c30b/hostprocess/calico/kube-proxy/start.ps1#L61

If the env var is empty (as was always the case with this difference), it defaults to the hostname, which might work in a great ammount of cases, or thus is my suspicion for it going undetected.

Using the same env var name in both setting it in the yaml and reading it in the ps1 script fixes it.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Issue #
(this felt so small that I didn't file an issue, please advise if I must)

**Requirements**

- [ ] Squash commits 
- [ ] Documentation
- [ ] Tests

**Notes**:


