### PR TITLE
Fix kube-proxy start.ps1

### DIFF
--- a/hostprocess/calico/kube-proxy/start.ps1
+++ b/hostprocess/calico/kube-proxy/start.ps1
@@ -53,15 +53,15 @@ $PlatformSupportDSR = $true
 #   https://github.com/kubernetes/kubernetes/blob/9f0f14952c51e7a5622eac05c541ba20b5821627/cmd/kubeadm/app/phases/addons/proxy/manifests.go
 Write-Host "Write files so the kubeconfig points to correct locations"
 mkdir -force /var/lib/kube-proxy/
-((Get-Content -path $env:CONTAINER_SANDBOX_MOUNT_POINT/var/lib/kube-proxy/kubeconfig.conf -Raw) -replace '/var',"$($env:CONTAINER_SANDBOX_MOUNT_POINT)/var") | Set-Content -Path $env:CONTAINER_SANDBOX_MOUNT_POINT/var/lib/kube-proxy/kubeconfig.conf
-cp $env:CONTAINER_SANDBOX_MOUNT_POINT/var/lib/kube-proxy/kubeconfig.conf /var/lib/kube-proxy/kubeconfig.conf
+((Get-Content -path $env:CONTAINER_SANDBOX_MOUNT_POINT/var/lib/kube-proxy/kubeconfig.conf -Raw) -replace '/var',"$($env:CONTAINER_SANDBOX_MOUNT_POINT)/var") | Set-Content -Path $env:CONTAINER_SANDBOX_MOUNT_POINT/var/lib/kube-proxy/kubeconfig-win.conf
+cp $env:CONTAINER_SANDBOX_MOUNT_POINT/var/lib/kube-proxy/kubeconfig-win.conf /var/lib/kube-proxy/kubeconfig.conf
 
 # Build up the arguments for starting kube-proxy.
 $argList = @(`
     "--hostname-override=$env:NODENAME", `
     "--v=4",`
     "--proxy-mode=kernelspace",`
-    "--kubeconfig=$env:CONTAINER_SANDBOX_MOUNT_POINT/var/lib/kube-proxy/kubeconfig.conf"`
+    "--kubeconfig=$env:CONTAINER_SANDBOX_MOUNT_POINT/var/lib/kube-proxy/kubeconfig-win.conf"`
 )
 $extraFeatures = @()
 

--- a/hostprocess/flannel/kube-proxy/start.ps1
+++ b/hostprocess/flannel/kube-proxy/start.ps1
@@ -52,8 +52,8 @@ function GetSourceVip($NetworkName)
 #   https://github.com/kubernetes/kubernetes/blob/9f0f14952c51e7a5622eac05c541ba20b5821627/cmd/kubeadm/app/phases/addons/proxy/manifests.go
 Write-Host "Write files so the kubeconfig points to correct locations"
 mkdir -force /var/lib/kube-proxy/
-((Get-Content -path $env:CONTAINER_SANDBOX_MOUNT_POINT/mounts/var/lib/kube-proxy/kubeconfig.conf -Raw) -replace '/var',"$($env:CONTAINER_SANDBOX_MOUNT_POINT)/var") | Set-Content -Path $env:CONTAINER_SANDBOX_MOUNT_POINT/mounts/var/lib/kube-proxy/kubeconfig.conf
-cp $env:CONTAINER_SANDBOX_MOUNT_POINT/mounts/var/lib/kube-proxy/kubeconfig.conf /var/lib/kube-proxy/kubeconfig.conf
+((Get-Content -path $env:CONTAINER_SANDBOX_MOUNT_POINT/mounts/var/lib/kube-proxy/kubeconfig.conf -Raw) -replace '/var',"$($env:CONTAINER_SANDBOX_MOUNT_POINT)/var") | Set-Content -Path $env:CONTAINER_SANDBOX_MOUNT_POINT/mounts/var/lib/kube-proxy/kubeconfig-win.conf
+cp $env:CONTAINER_SANDBOX_MOUNT_POINT/mounts/var/lib/kube-proxy/kubeconfig-win.conf /var/lib/kube-proxy/kubeconfig.conf
 
 Write-Host "Finding sourcevip"
 $vip = GetSourceVip -NetworkName $env:KUBE_NETWORK
@@ -64,7 +64,7 @@ $arguements = "--v=6",
         "--feature-gates=WinOverlay=true",
         "--proxy-mode=kernelspace",
         "--source-vip=$vip",
-        "--kubeconfig=$env:CONTAINER_SANDBOX_MOUNT_POINT/mounts/var/lib/kube-proxy/kubeconfig.conf"
+        "--kubeconfig=$env:CONTAINER_SANDBOX_MOUNT_POINT/mounts/var/lib/kube-proxy/kubeconfig-win.conf"
 
 $exe = "$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/kube-proxy.exe " + ($arguements -join " ")
 


### PR DESCRIPTION
**Reason for PR**:
<!-- What does this PR improve or fix? -->
Fix kube-proxy start.ps1. To avoid ConfigMap mount reset, a copy of kubeconfig.conf should be used as kube-proxy.exe's arg.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Issue #341

**Requirements**

- [ ] Sqaush commits 
- [ ] Documentation
- [ ] Tests

**Notes**:


