### PR TITLE
docs: Consistent format of versions input for scripts

### DIFF
--- a/guides/guide-for-adding-windows-node.md
+++ b/guides/guide-for-adding-windows-node.md
@@ -42,10 +42,10 @@ curl.exe -LO https://raw.githubusercontent.com/kubernetes-sigs/sig-windows-tools
 ```PowerShell
 # Install kubelet and kubeadm
 curl.exe -LO https://raw.githubusercontent.com/kubernetes-sigs/sig-windows-tools/master/hostprocess/PrepareNode.ps1
-.\PrepareNode.ps1 -KubernetesVersion v1.25.3
+.\PrepareNode.ps1 -KubernetesVersion 1.25.3
 ```
 
-> **Note** If you want to install another version of kubernetes, modify v1.25.3 with the version you want to install
+> **Note** If you want to install another version of kubernetes, modify 1.25.3 with the version you want to install
 
 3. Run `kubeadm` to join the node
 


### PR DESCRIPTION
**Reason for PR**:

This make versions input a no-brainer as currently it may alert users with unnecessary questions "is that a typo? which one is correct? shall I use `v` prefix for the ContainerD installer?", etc.

The `PrepareNode.ps1` can handle both formats `X.Y.Z` and `vX.Y.Z` though, but one has to read the script to learn it.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Issue #

**Requirements**

- [ ] Sqaush commits 
- [ ] Documentation
- [ ] Tests

**Notes**:


