### PR TITLE
Add directory of wmic.exe to path as required by csi-proxy

### DIFF
--- a/hostprocess/csi-proxy/Dockerfile.windows
+++ b/hostprocess/csi-proxy/Dockerfile.windows
@@ -11,5 +11,5 @@ RUN git clone https://github.com/kubernetes-csi/csi-proxy.git /go/csi-proxy &&\
 
 FROM ${REGISTRY}/${WINDOWS_BASE_IMAGE}:${WINDOWS_VERSION}
 COPY --from=builder /go/csi-proxy/bin/csi-proxy.exe /csi-proxy.exe
-ENV PATH="C:\Windows\system32;C:\Windows;C:\WINDOWS\System32\WindowsPowerShell\v1.0\;"
+ENV PATH="C:\Windows\system32;C:\Windows;C:\WINDOWS\System32\WindowsPowerShell\v1.0\;C:\Windows\System32\wbem;"
 ENTRYPOINT ["csi-proxy.exe", "-v", "4"]


### PR DESCRIPTION
**Reason for PR**:
Fixes `wmic.exe` not found during CSI driver registration.
```
I0131 16:03:31.383613    6684 main.go:121] Received NotifyRegistrationStatus call: &RegistrationStatus{PluginRegistered:false,Error:RegisterPlugin error -- plugin registration failed with err: rpc error: code = Internal desc = failed to get system uuid for node VM with error: rpc error: code = Unknown desc = exec: "wmic": executable file not found in %PATH%,}
E0131 16:03:31.383613    6684 main.go:123] Registration process failed with error: RegisterPlugin error -- plugin registration failed with err: rpc error: code = Internal desc = failed to get system uuid for node VM with error: rpc error: code = Unknown desc = exec: "wmic": executable file not found in %PATH%, restarting registration container.
```

https://github.com/kubernetes-csi/csi-proxy/blob/07be14dabebca5d1590e670f9a796fcfce44d6e6/pkg/os/system/api.go#L37


**Issue Fixed**:
Issue #358

**Requirements**

- [ ] Sqaush commits 
- [ ] Documentation
- [ ] Tests

**Notes**:


