### PR TITLE
update curl.exe to use wget

### DIFF
--- a/hostprocess/PrepareNode.ps1
+++ b/hostprocess/PrepareNode.ps1
@@ -29,7 +29,7 @@ $ErrorActionPreference = 'Stop'
 
 function DownloadFile($destination, $source) {
     Write-Host("Downloading $source to $destination")
-    curl.exe --silent --fail -Lo $destination $source
+    wget $source -outfile $destination
 
     if (!$?) {
         Write-Error "Download $source failed"


### PR DESCRIPTION
curl fails because of an old certification. hence, using wget is more reliable

**Reason for PR**:
Using curl.exe resulted in a lot of problems downloading files. the issue seems to be a certificate issue


