### PR TITLE
Allow passing build arg when building csi-proxy Host Process Container

### DIFF
--- a/hostprocess/csi-proxy/Dockerfile.windows
+++ b/hostprocess/csi-proxy/Dockerfile.windows
@@ -1,15 +1,16 @@
 ARG REGISTRY=mcr.microsoft.com/oss/kubernetes
 ARG WINDOWS_BASE_IMAGE=windows-host-process-containers-base-image
-ARG WINDOWS_VERSION=v1.0.0
+ARG WINDOWS_BASE_IMAGE_VERSION=v1.0.0
+ARG BUILDER_BASE_IMAGE=golang
 
-FROM --platform=linux/amd64 golang:1.20 as builder
+FROM --platform=linux/amd64 ${BUILDER_BASE_IMAGE}:1.20 as builder
 ARG CSI_PROXY_VERSION=v1.1.3
 RUN git clone https://github.com/kubernetes-csi/csi-proxy.git /go/csi-proxy &&\
     cd /go/csi-proxy &&\
     git checkout tags/${CSI_PROXY_VERSION} &&\
     make build
 
-FROM ${REGISTRY}/${WINDOWS_BASE_IMAGE}:${WINDOWS_VERSION}
+FROM ${REGISTRY}/${WINDOWS_BASE_IMAGE}:${WINDOWS_BASE_IMAGE_VERSION}
 COPY --from=builder /go/csi-proxy/bin/csi-proxy.exe /csi-proxy.exe
 ENV PATH="C:\Windows\system32;C:\Windows;C:\WINDOWS\System32\WindowsPowerShell\v1.0\;C:\Windows\System32\wbem;"
 ENTRYPOINT ["csi-proxy.exe", "-v", "4"]

--- a/hostprocess/csi-proxy/build.sh
+++ b/hostprocess/csi-proxy/build.sh
@@ -34,13 +34,22 @@ if [[ "$push" == "1" ]]; then
   output="type=registry"
 fi
 
-repository=${repository:-"ghcr.io/kubernetes-sigs/sig-windows"}
+CSI_PROXY_VERSION=${CSI_PROXY_VERSION:-"v1.1.3"}
+REPOSITORY=${REPOSITORY:-"ghcr.io/kubernetes-sigs/sig-windows"}
+WINDOWS_BASE_IMAGE_REGISTRY=${WINDOWS_BASE_IMAGE_REGISTRY:-"mcr.microsoft.com/oss/kubernetes"}
+WINDOWS_BASE_IMAGE=${WINDOWS_BASE_IMAGE:-"windows-host-process-containers-base-image"}
+WINDOWS_BASE_IMAGE_VERSION=${WINDOWS_BASE_IMAGE_VERSION:-"v1.0.0"}
+BUILDER_BASE_IMAGE=${BUILDER_BASE_IMAGE:-"golang"}
 
 set -x
 
 docker buildx create --name img-builder --use --platform windows/amd64
 trap 'docker buildx rm img-builder' EXIT
 
-
-docker buildx build --platform windows/amd64 --output=$output -f Dockerfile.windows -t ${repository}/csi-proxy:${version} .
-
+docker buildx build --platform windows/amd64 --output=$output -f Dockerfile.windows \
+    --build-arg REGISTRY=${WINDOWS_BASE_IMAGE_REGISTRY} \
+    --build-arg WINDOWS_BASE_IMAGE=${WINDOWS_BASE_IMAGE} \
+    --build-arg WINDOWS_BASE_IMAGE_VERSION=${WINDOWS_BASE_IMAGE_VERSION} \
+    --build-arg BUILDER_BASE_IMAGE=${BUILDER_BASE_IMAGE} \
+    --build-arg CSI_PROXY_VERSION=${CSI_PROXY_VERSION} \
+    -t ${REPOSITORY}/csi-proxy:${version} .

--- a/hostprocess/csi-proxy/csi-proxy.yaml
+++ b/hostprocess/csi-proxy/csi-proxy.yaml
@@ -21,4 +21,4 @@ spec:
       hostNetwork: true
       containers:
         - name: csi-proxy
-          image: ghcr.io/kubernetes-sigs/sig-windows/csi-proxy:v1.1.2
+          image: ghcr.io/kubernetes-sigs/sig-windows/csi-proxy:v1.1.3


### PR DESCRIPTION
**Reason for PR**:
Allow passing build arg via env vars to container building process

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Issue #364 

**Requirements**

- [ ] Sqaush commits 
- [ ] Documentation
- [ ] Tests

**Notes**:


