### PR TITLE
Update kube-calico-rbac.yml

### DIFF
--- a/hostprocess/calico/kube-calico-rbac.yml
+++ b/hostprocess/calico/kube-calico-rbac.yml
@@ -8,7 +8,7 @@ metadata:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: calico-node
+  name: calico-node-windows
 rules:
   - apiGroups: [""]
     resources:
@@ -72,6 +72,10 @@ rules:
       - networkpolicies
       - clusterinformations
       - hostendpoints
+      - ipreservations
+      - ipamblocks
+      - ipamconfigs
+      - blockaffinities
     verbs:
       - create
       - get
@@ -82,11 +86,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: calico-node
+  name: calico-node-windows
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: calico-node
+  name: calico-node-windows
 subjects:
   - kind: ServiceAccount
     name: calico-node


### PR DESCRIPTION
Include missing resources for calico-node cluster role Update names to avoid conflicts with existing resources

**Reason for PR**:
The four additional resources are required. The name change is due to calico using the same name for cluster roles and bindings.



