### PR TITLE
Update kube-calico-rbac.yml

### DIFF
--- a/hostprocess/calico/kube-calico-rbac.yml
+++ b/hostprocess/calico/kube-calico-rbac.yml
@@ -8,7 +8,7 @@ metadata:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: calico-node
+  name: calico-node-windows
 rules:
   - apiGroups: [""]
     resources:
@@ -26,15 +26,12 @@ rules:
   - apiGroups: [""]
     resources:
       - pods
+      - services
+      - configmaps
     verbs:
       - get
       - list
       - watch
-  - apiGroups: [""]
-    resources:
-      - services
-    verbs:
-      - get
   - apiGroups: [""]
     resources:
       - endpoints
@@ -43,11 +40,13 @@ rules:
   - apiGroups: [""]
     resources:
       - nodes
+      - nodes/status
     verbs:
       - get
       - list
       - update
       - watch
+      - patch
   - apiGroups: ["extensions"]
     resources:
       - networkpolicies
@@ -72,21 +71,34 @@ rules:
       - networkpolicies
       - clusterinformations
       - hostendpoints
+      - ipreservations
+      - ipamblocks
+      - ipamconfigs
+      - blockaffinities
+      - networksets
+      - ipamhandles
     verbs:
       - create
       - get
       - list
       - update
       - watch
+  - apiGroups: ["discovery.k8s.io"]
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: calico-node
+  name: calico-node-windows
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: calico-node
+  name: calico-node-windows
 subjects:
   - kind: ServiceAccount
     name: calico-node


### PR DESCRIPTION
Additional verbs and resources required by the proxy and node for windows
As well as a name change for the cluster role binding and cluster role as the old name conflicts with one that's existing.