### PR TITLE
Updating permissions for windows-container-nightly.yml workflow

### DIFF
--- a/.github/workflows/windows-containerd-nightly.yml
+++ b/.github/workflows/windows-containerd-nightly.yml
@@ -7,6 +7,9 @@ on:
     - cron: '45 0 * * *' # Every day at 00:45 UTC 
   workflow_dispatch:
 
+permissions:
+  contents: write # Allow the action to update the `container-nightly` GH release
+
 jobs:
 
   build:


### PR DESCRIPTION
**Reason for PR**:
A few weeks ago the default permissions for GH_TOKEN were updated and we need to explicitly request permissions to push the releases now


**Issue Fixed**:
Fixing ctrd-nightly gh action

**Requirements**

- [ ] Sqaush commits 
- [ ] Documentation
- [ ] Tests

**Notes**:


