### PR TITLE
Remove flannel reference from kube-proxy workflow

### DIFF
--- a/.github/workflows/build-kube-proxy-images.yml
+++ b/.github/workflows/build-kube-proxy-images.yml
@@ -18,6 +18,3 @@ jobs:
         echo "${{ secrets.DOCKER_SECRET }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
         pushd ./hostprocess/calico 
         ./build.sh -p ${{ github.event.inputs.proxy_version }}
-        popd
-        pushd ./hostprocess/flannel
-        ./build.sh -p ${{ github.event.inputs.proxy_version}}


### PR DESCRIPTION
**Reason for PR**:
Support for flannel was removed in https://github.com/kubernetes-sigs/sig-windows-tools/pull/385. Reflect that in the build-kube-proxy-images workflow
