### PR TITLE
Stop checking for *-flannel-hostprocess kube-proxy images

### DIFF
--- a/hack/test-kube-proxy-images.ps1
+++ b/hack/test-kube-proxy-images.ps1
@@ -19,7 +19,7 @@ foreach ($tag in $json.tags) {
         continue
     }
 
-    foreach ($flavor in @("-calico-hostprocess", "-flannel-hostprocess")) {
+    foreach ($flavor in @("-calico-hostprocess")) {
         $image = "sigwindowstools/kube-proxy:$tag$flavor"
         Write-Output "Checking for image $image"
         docker manifest inspect $image | Out-Null


### PR DESCRIPTION
**Reason for PR**:
We stopped building flannel kube-proxy images so we should not check for them in test-kube-proxy-images.ps1

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Issue #

**Requirements**

- [ ] Sqaush commits 
- [ ] Documentation
- [ ] Tests

**Notes**:

/assign @aravindhp @jsturtevant @zylxjtu 


