### PR TITLE
Synchronize automatically kube-proxy images

### DIFF
--- a/.github/workflows/build-kube-proxy-images.yml
+++ b/.github/workflows/build-kube-proxy-images.yml
@@ -7,14 +7,25 @@ on:
       proxy_version:
         description: 'Version of kube-proxy to build (ex: v1.27.1)'
         required: true
+      repository:
+        description: 'Repository to push the image to (ex: docker.io/sigwindowstools)'
+        required: false
+        default: 'docker.io/sigwindowstools'
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+
+    - name: Login to DockerHub
+      if: startsWith(github.event.inputs.repository, 'docker.io')
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_SECRET }}
+
     - name: Build and push images
       run: |
-        echo "${{ secrets.DOCKER_SECRET }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-        pushd ./hostprocess/calico 
-        ./build.sh -p ${{ github.event.inputs.proxy_version }}
+        pushd ./hostprocess/calico
+        ./build.sh -p ${{ github.event.inputs.proxy_version }} -r ${{ github.event.inputs.repository }}

--- a/.github/workflows/sync-kube-proxy-images.yaml
+++ b/.github/workflows/sync-kube-proxy-images.yaml
@@ -1,0 +1,92 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Sync Kube-Proxy images
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # Every day at 00:00 UTC
+  workflow_dispatch:
+    inputs:
+      repository:
+        description: 'Repository to push the image to (ex: docker.io/sigwindowstools)'
+        required: false
+        default: 'docker.io/sigwindowstools'
+
+env:
+  REPOSITORY: ${{ github.event.inputs.repository || 'docker.io/sigwindowstools' }}
+
+permissions:
+  actions: write
+
+jobs:
+  sync:
+    name: Find and sync missing kube-proxy images
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Login to DockerHub
+      if: startsWith(env.REPOSITORY, 'docker.io')
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_SECRET }}
+
+    - name: Find and trigger builds for missing images
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+
+        REPOSITORY="${{ env.REPOSITORY }}"
+        MIN_VERSION="1.33"
+        SUFFIX="-calico-hostprocess"
+        MISSING=()
+
+        # Fetch all kube-proxy tags from registry.k8s.io
+        echo "Fetching kube-proxy tags from registry.k8s.io..."
+        TAGS=$(curl -sL "https://registry.k8s.io/v2/kube-proxy/tags/list" | jq -r '.tags[]')
+
+        for TAG in $TAGS; do
+          # Must start with 'v'
+          [[ "$TAG" != v* ]] && continue
+
+          # Skip pre-release tags (contain a hyphen after stripping 'v')
+          VER="${TAG#v}"
+          [[ "$VER" == *-* ]] && continue
+
+          # Version comparison: must be >= MIN_VERSION
+          LOWEST=$(printf '%s\n' "$MIN_VERSION" "$VER" | sort -V | head -n1)
+          [[ "$LOWEST" != "$MIN_VERSION" ]] && continue
+
+          IMAGE="${REPOSITORY}/kube-proxy:${TAG}${SUFFIX}"
+          echo "Checking ${IMAGE} ..."
+
+          if docker manifest inspect "$IMAGE" > /dev/null 2>&1; then
+            echo "  exists"
+          else
+            echo "  missing"
+            MISSING+=("$TAG")
+          fi
+        done
+
+        echo ""
+        echo "=== Summary ==="
+        if [[ ${#MISSING[@]} -eq 0 ]]; then
+          echo "All kube-proxy images are up to date."
+          exit 0
+        fi
+
+        echo "Missing images (${#MISSING[@]}):"
+        for TAG in "${MISSING[@]}"; do
+          echo "  - ${REPOSITORY}/kube-proxy:${TAG}${SUFFIX}"
+        done
+
+        echo ""
+        echo "Triggering builds..."
+        for TAG in "${MISSING[@]}"; do
+          echo "  Dispatching build for ${TAG} -> ${REPOSITORY} ..."
+          gh workflow run build-kube-proxy-images.yml \
+            -f proxy_version="$TAG" \
+            -f repository="$REPOSITORY"
+        done


### PR DESCRIPTION
**Reason for PR**:

Currently the build-kube-proxy-images.yml workflow must be triggered manually, this PR automates that task so that it's made automatically for every new version. We only check versions starting on 1.33 because it's the oldest maintained branch.

This was tested here: https://github.com/juanluisvaladas/sig-windows-tools/actions/runs/22623814294/job/65555151567#step:4:62

In this test we can see the images for 1.35 not being triggered because they existed from previous execution runs and we see the workflows dispatched for the missing images.

**Requirements**

- [x] Sqaush commits 
- [x] Documentation
- [x] Tests

**Notes**:

Tested manually and I don't think docs are required for this change.