### PR TITLE
Remove '--pod-infra-container-image' kubelet flag

### DIFF
--- a/hostprocess/PrepareNode.ps1
+++ b/hostprocess/PrepareNode.ps1
@@ -70,7 +70,7 @@ New-Item -path C:\var\lib\kubelet\etc\kubernetes\pki -type SymbolicLink -value C
 # dockershim related flags (--image-pull-progress-deadline=20m and --network-plugin=cni)  are removed in k8s v1.24
 # Link to changelog: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md
 
-$cmd_commands=@("C:\k\kubelet.exe ", '$global:KubeletArgs ', '--cert-dir=$env:SYSTEMDRIVE\var\lib\kubelet\pki ', "--config=/var/lib/kubelet/config.yaml ", "--bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf ", "--kubeconfig=/etc/kubernetes/kubelet.conf ", "--hostname-override=$HostnameOverride ", '--pod-infra-container-image=`"mcr.microsoft.com/oss/kubernetes/pause:3.6`" ', "--enable-debugging-handlers ", "--cgroups-per-qos=false ", '--enforce-node-allocatable=`"`" ', '--resolv-conf=`"`" ')
+$cmd_commands=@("C:\k\kubelet.exe ", '$global:KubeletArgs ', '--cert-dir=$env:SYSTEMDRIVE\var\lib\kubelet\pki ', "--config=/var/lib/kubelet/config.yaml ", "--bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf ", "--kubeconfig=/etc/kubernetes/kubelet.conf ", "--hostname-override=$HostnameOverride ", "--enable-debugging-handlers ", "--cgroups-per-qos=false ", '--enforce-node-allocatable=`"`" ', '--resolv-conf=`"`" ')
 [version]$CurrentVersion = $($KubernetesVersion.Split("v") | Select -Index 1)
 [version]$V1_24_Version = '1.24'
 if ($CurrentVersion -lt $V1_24_Version) {
@@ -79,6 +79,11 @@ if ($CurrentVersion -lt $V1_24_Version) {
 [version]$V1_26_Version = '1.26'
 if ($CurrentVersion -lt $V1_26_Version) {
     $cmd_commands += ("--log-dir=/var/log/kubelet ", "--logtostderr=false ")
+}
+
+[version]$V1_27_Version = '1.27'
+if ($CurrentVersion -lt $V1_27_Version) {
+    $cmd_commands += ('--pod-infra-container-image=`"mcr.microsoft.com/oss/kubernetes/pause:3.6`" ')
 }
 
 $StartKubeletFileContent = '$FileContent = Get-Content -Path "/var/lib/kubelet/kubeadm-flags.env"


### PR DESCRIPTION
Remove the kubelet flag '--pod-infra-container-image' from PrepareNode.ps1. This flag has been deprecated since Kubernetes v1.27, and has been removed as of v1.34. When present in k8s v1.34+, it causes kubelet to fail to start with the error:

```
"command failed" err="failed to parse kubelet flag: unknown flag: --pod-infra-container-image"
```

**Reason for PR**:
<!-- What does this PR improve or fix? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Issue #

**Requirements**

- [ ] Sqaush commits 
- [ ] Documentation
- [ ] Tests

**Notes**:


