### PR TITLE
Sync kube-proxy pre-release versions

### DIFF
--- a/.github/workflows/sync-kube-proxy-images.yaml
+++ b/.github/workflows/sync-kube-proxy-images.yaml
@@ -51,11 +51,8 @@ jobs:
           # Must start with 'v'
           [[ "$TAG" != v* ]] && continue
 
-          # Skip pre-release tags (contain a hyphen after stripping 'v')
-          VER="${TAG#v}"
-          [[ "$VER" == *-* ]] && continue
-
           # Version comparison: must be >= MIN_VERSION
+          VER="${TAG#v}"
           LOWEST=$(printf '%s\n' "$MIN_VERSION" "$VER" | sort -V | head -n1)
           [[ "$LOWEST" != "$MIN_VERSION" ]] && continue
 

--- a/hack/test-kube-proxy-images.ps1
+++ b/hack/test-kube-proxy-images.ps1
@@ -12,9 +12,6 @@ foreach ($tag in $json.tags) {
     if (-not($tag.StartsWith("v"))) {
         continue
     }
-    if ($tag.Contains("-")) {
-        continue
-    }
     if ([Version]($tag.TrimStart('v')) -lt [Version]($minK8sVersion.TrimStart('v'))) {
         continue
     }


### PR DESCRIPTION
**Reason for PR**:
In k0s we'd like to have pre-release tags so that we can bump the kubernetes version before the final release.
This modifies the workflow to sync images so that the pre release images and also checks them in the job to validate they are synced.

**Issue Fixed**:
**Requirements**

- [x] Squash commits 
- [ ] Documentation (I don't think this is truly required)
- [x] Tests

**Notes**: